### PR TITLE
feat(ui): 手札・山札選択時に戦具効果を併記

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,6 +51,11 @@ def render_card_info(card):
     return f"{card.name} {JANKEN_ICONS.get(card.janken, '')}{card.base_point}"
 
 
+def render_card_option_label(card):
+    description = card.effect.description if card.effect else "（効果なし）"
+    return f"{render_card_info(card)}｜{description}"
+
+
 def render_card_detail(card):
     with st.container(border=True):
         st.markdown(f"**{render_card_info(card)}**")
@@ -106,7 +111,7 @@ def find_card_by_id(cards, card_id):
 
 
 def card_id_options(cards):
-    labels = {card.id: render_card_info(card) for card in cards}
+    labels = {card.id: render_card_option_label(card) for card in cards}
     return list(labels), labels
 
 


### PR DESCRIPTION
### Motivation
- 手札や山札からカードを選ぶときに表示がカード名と基礎点のみで、戦具の効果説明が見えず選択しづらかったため表示を改善する。 

### Description
- `app.py` に `render_card_option_label` を追加してカード名・じゃんけん種別・基礎点に加えて戦具効果説明（効果なし含む）を1行で返すようにした。 
- `card_id_options` を `render_card_info` から `render_card_option_label` を使うように切り替え、`selectbox`/`multiselect` 等の選択UIで効果説明が表示されるようにした。 

### Testing
- `ruff format app.py` を実行してフォーマットチェックは成功した。 
- `ruff check --fix --extend-select I` を実行して静的チェックは成功した。 
- `pytest` を実行して単体テストはすべて通過した（25 tests passed）。 
- `uv run pytest` はこの環境での依存取得時にネットワーク経路の問題により失敗したため実行できなかった。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed99fadbc4832c9c9d9e1485ab8a41)