### PR TITLE
feat(scripts): add effect implementation progress checker

### DIFF
--- a/scripts/check_unimplemented_effects.py
+++ b/scripts/check_unimplemented_effects.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+REGISTER_PATTERN = re.compile(r'@register\("([^"]+)"\)')
+
+
+def extract_registered_types(effect_handlers_path: Path) -> set[str]:
+    content = effect_handlers_path.read_text(encoding="utf-8")
+    return set(REGISTER_PATTERN.findall(content))
+
+
+def load_cards(cards_path: Path) -> list[dict]:
+    cards: list[dict] = []
+    with cards_path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            cards.append(json.loads(line))
+    return cards
+
+
+def find_unimplemented_cards(
+    cards: list[dict], implemented_types: set[str]
+) -> list[dict]:
+    unimplemented: list[dict] = []
+    for card in cards:
+        effect = card.get("effect")
+        if not effect:
+            continue
+        effect_type = effect.get("type")
+        if effect_type is None:
+            continue
+        if effect_type not in implemented_types:
+            unimplemented.append(
+                {
+                    "id": card["id"],
+                    "name": card["name"],
+                    "type": effect_type,
+                }
+            )
+    return unimplemented
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    cards_path = repo_root / "cards.jsonl"
+    effect_handlers_path = repo_root / "shadow_bout" / "effect_handlers.py"
+
+    implemented_types = extract_registered_types(effect_handlers_path)
+    cards = load_cards(cards_path)
+    unimplemented = find_unimplemented_cards(cards, implemented_types)
+
+    print("未実装カード一覧（id/name/type）")
+    for card in unimplemented:
+        print(f"- {card['id']} / {card['name']} / {card['type']}")
+
+    print("\n未実装typeの件数集計")
+    type_counter = Counter(card["type"] for card in unimplemented)
+    for effect_type, count in sorted(type_counter.items()):
+        print(f"- {effect_type}: {count}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- カード定義の `effect.type` と `shadow_bout/effect_handlers.py` の `@register("...")` を突き合わせて、未実装のカード効果を機械的に把握できるツールが必要だった。 
- CI やローカル実行で毎回確認できるように、簡潔なスクリプトで進捗を出力したいという目的がある。

### Description
- `scripts/check_unimplemented_effects.py` を追加し、`@register("...")` を正規表現で解析して実装済みの effect type を抽出する処理を実装した。 
- `cards.jsonl` を読み込み各カードの `effect.type` と照合して未実装カードのリスト（`id/name/type`）を作成し、未実装 type の件数集計も出力するようにした。 
- スクリプトはリポジトリルート基準で `cards.jsonl` と `shadow_bout/effect_handlers.py` を参照するため、CI/ローカルで同じ実行方法（`python scripts/check_unimplemented_effects.py`）で動作する。

### Testing
- `python scripts/check_unimplemented_effects.py` を実行して期待する出力が得られることを確認し成功した。 
- `ruff format` と `ruff check --fix --extend-select I` を実行してコード整形・静的チェックが通過した。 
- `.venv/bin/python -m pytest` を実行しテストスイートがすべて成功（25 件のテストがすべて通過）した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35fd7604c832cb79c57826c73ff2b)