### PR TITLE
feat(engine): 次ラウンド1回適用の持ち越し効果基盤を追加

### DIFF
--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -592,25 +592,25 @@ def proceed_to_next(game_state: GameState) -> GameState:
     if game_state.round_number >= 4:
         return replace(game_state, phase=Phase.RESULT)
 
+    if not game_state.player.hand and not game_state.npc.hand:
+        return replace(game_state, phase=Phase.RESULT)
+
     next_round = game_state.round_number + 1
 
     while next_round <= 4:
-        if not game_state.player.hand and not game_state.npc.hand:
-            return replace(game_state, phase=Phase.RESULT)
+        round_state = replace(game_state, round_number=next_round)
+        round_state = apply_next_round_carryover_effects(round_state)
 
-        forfeit_side = check_forfeit(game_state.player, game_state.npc)
+        if not round_state.player.hand and not round_state.npc.hand:
+            return replace(round_state, phase=Phase.RESULT)
+
+        forfeit_side = check_forfeit(round_state.player, round_state.npc)
         if forfeit_side is None:
-            next_state = replace(
-                game_state,
-                round_number=next_round,
-                phase=Phase.SELECT,
-            )
-            return apply_next_round_carryover_effects(next_state)
+            return replace(round_state, phase=Phase.SELECT)
 
-        game_state = apply_forfeit(game_state, forfeit_side)
+        game_state = apply_forfeit(round_state, forfeit_side)
         game_state = replace(
             game_state,
-            round_number=next_round,
             battle_log=game_state.battle_log
             + [format_forfeit_log(next_round, forfeit_side)],
         )

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -202,6 +202,40 @@ def reset_round_state(game_state: GameState) -> GameState:
     )
 
 
+def apply_next_round_carryover_effects(game_state: GameState) -> GameState:
+    """次ラウンド開始時に1回だけ適用して消える持ち越し効果を適用する。"""
+    player_bonus = game_state.player.next_round_point_modifier
+    npc_bonus = game_state.npc.next_round_point_modifier
+
+    new_player = replace(
+        game_state.player,
+        point_modifier=game_state.player.point_modifier + player_bonus,
+        next_round_point_modifier=0,
+    )
+    new_npc = replace(
+        game_state.npc,
+        point_modifier=game_state.npc.point_modifier + npc_bonus,
+        next_round_point_modifier=0,
+    )
+
+    logs: list[str] = []
+    if player_bonus:
+        logs.append(
+            f"R{game_state.round_number}: 持ち越し効果適用 あなた ポイント{player_bonus:+d}"
+        )
+    if npc_bonus:
+        logs.append(
+            f"R{game_state.round_number}: 持ち越し効果適用 NPC ポイント{npc_bonus:+d}"
+        )
+
+    return replace(
+        game_state,
+        player=new_player,
+        npc=new_npc,
+        battle_log=game_state.battle_log + logs,
+    )
+
+
 def set_battle_cards_as_played(
     game_state: GameState, player_card: Card, npc_card: Card
 ) -> GameState:
@@ -566,11 +600,12 @@ def proceed_to_next(game_state: GameState) -> GameState:
 
         forfeit_side = check_forfeit(game_state.player, game_state.npc)
         if forfeit_side is None:
-            return replace(
+            next_state = replace(
                 game_state,
                 round_number=next_round,
                 phase=Phase.SELECT,
             )
+            return apply_next_round_carryover_effects(next_state)
 
         game_state = apply_forfeit(game_state, forfeit_side)
         game_state = replace(

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -114,6 +114,7 @@ class PlayerState:
     draw_stock: list[Card] = field(default_factory=list)
     revealed_card_ids: frozenset[str] = frozenset()
     point_modifier: int = 0
+    next_round_point_modifier: int = 0
     effect_negated: bool = False
 
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -235,3 +235,22 @@ def test_proceed_to_next_applies_carryover_once_on_round_start(mock_cards):
     assert third_state.round_number == 3
     assert third_state.player.point_modifier == 0
     assert third_state.npc.point_modifier == 0
+
+
+def test_proceed_to_next_consumes_carryover_on_forfeit_round(mock_cards):
+    forfeited_1, npc_card, _, _ = mock_cards
+    state = GameState(
+        player=PlayerState(hand=[], deck=[forfeited_1], next_round_point_modifier=4),
+        npc=PlayerState(hand=[npc_card], next_round_point_modifier=-2),
+        round_number=1,
+        phase=Phase.REVEAL,
+    )
+
+    new_state = proceed_to_next(state)
+
+    assert new_state.phase == Phase.RESULT
+    assert new_state.round_number == 4
+    assert new_state.player.next_round_point_modifier == 0
+    assert new_state.npc.next_round_point_modifier == 0
+    assert "R2: 持ち越し効果適用 あなた ポイント+4" in new_state.battle_log
+    assert "R2: 持ち越し効果適用 NPC ポイント-2" in new_state.battle_log

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -212,3 +212,26 @@ def test_proceed_to_next_ends_when_both_players_cannot_play(mock_cards):
 
     assert new_state.phase == Phase.RESULT
     assert new_state.round_number == 1
+
+
+def test_proceed_to_next_applies_carryover_once_on_round_start(mock_cards):
+    p_card, n_card, _, _ = mock_cards
+    state = GameState(
+        player=PlayerState(hand=[p_card], next_round_point_modifier=2),
+        npc=PlayerState(hand=[n_card], next_round_point_modifier=-1),
+        round_number=1,
+        phase=Phase.REVEAL,
+    )
+
+    next_state = proceed_to_next(state)
+    assert next_state.round_number == 2
+    assert next_state.phase == Phase.SELECT
+    assert next_state.player.point_modifier == 2
+    assert next_state.npc.point_modifier == -1
+    assert next_state.player.next_round_point_modifier == 0
+    assert next_state.npc.next_round_point_modifier == 0
+
+    third_state = proceed_to_next(next_state)
+    assert third_state.round_number == 3
+    assert third_state.player.point_modifier == 0
+    assert third_state.npc.point_modifier == 0


### PR DESCRIPTION
## 概要
- `PlayerState` に次ラウンド1回適用の持ち越しポイント値を追加
- `proceed_to_next` の `SELECT` 遷移直前に持ち越しを適用して消去
- 手動注入テストを追加し、1回適用を確認

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
