### PR TITLE
fix(effects): conditional_debuff_nextのバー条件を反映

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -235,6 +235,41 @@ def effect_buff_dynamic(state: GameState, side: Side, card: Card) -> GameState:
     )
 
 
+@register("buff_next")
+def effect_buff_next(state: GameState, side: Side, card: Card) -> GameState:
+    p_state = get_player_state(state, side)
+    bonus = int(card.effect.value or 0)
+    state = update_player(
+        state,
+        side,
+        next_round_point_modifier=p_state.next_round_point_modifier + bonus,
+    )
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 次ラウンドのポイント{bonus:+d}"],
+    )
+
+
+@register("conditional_debuff_next")
+def effect_conditional_debuff_next(
+    state: GameState, side: Side, card: Card
+) -> GameState:
+    opp_side = get_opponent_side(side)
+    opp_state = get_player_state(state, opp_side)
+    debuff = int(card.effect.value or 0)
+    state = update_player(
+        state,
+        opp_side,
+        next_round_point_modifier=opp_state.next_round_point_modifier + debuff,
+    )
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手の次ラウンドのポイント{debuff:+d}"],
+    )
+
+
 @register("negate")
 def effect_negate(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -261,12 +261,14 @@ def effect_conditional_debuff_next(
     state = update_player(
         state,
         opp_side,
-        next_round_point_modifier=opp_state.next_round_point_modifier + debuff,
+        next_round_conditional_point_modifier_non_wildcard=(
+            opp_state.next_round_conditional_point_modifier_non_wildcard + debuff
+        ),
     )
     return replace(
         state,
         battle_log=state.battle_log
-        + [f"{card.name}の効果発動: 相手の次ラウンドのポイント{debuff:+d}"],
+        + [f"{card.name}の効果発動: 相手の次ラウンド(バー以外)のポイント{debuff:+d}"],
     )
 
 

--- a/shadow_bout/effect_scoring.py
+++ b/shadow_bout/effect_scoring.py
@@ -1,10 +1,23 @@
 from dataclasses import replace
 
-from shadow_bout.models import Card, GameState, Phase, PlayerState, RoundOutcome, Side
+from shadow_bout.models import (
+    Card,
+    GameState,
+    Janken,
+    Phase,
+    PlayerState,
+    RoundOutcome,
+    Side,
+)
 
 
 def calculate_effective_point(card: Card, player_state: PlayerState) -> int:
-    return card.base_point + player_state.point_modifier
+    conditional = (
+        player_state.conditional_point_modifier_non_wildcard
+        if card.janken != Janken.WILDCARD
+        else 0
+    )
+    return card.base_point + player_state.point_modifier + conditional
 
 
 def resolve_post_effect_skipped(state: GameState) -> GameState:

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -181,11 +181,13 @@ def reset_round_state(game_state: GameState) -> GameState:
     new_player = replace(
         game_state.player,
         point_modifier=0,
+        conditional_point_modifier_non_wildcard=0,
         effect_negated=False,
     )
     new_npc = replace(
         game_state.npc,
         point_modifier=0,
+        conditional_point_modifier_non_wildcard=0,
         effect_negated=False,
     )
     return replace(
@@ -211,11 +213,21 @@ def apply_next_round_carryover_effects(game_state: GameState) -> GameState:
         game_state.player,
         point_modifier=game_state.player.point_modifier + player_bonus,
         next_round_point_modifier=0,
+        conditional_point_modifier_non_wildcard=(
+            game_state.player.conditional_point_modifier_non_wildcard
+            + game_state.player.next_round_conditional_point_modifier_non_wildcard
+        ),
+        next_round_conditional_point_modifier_non_wildcard=0,
     )
     new_npc = replace(
         game_state.npc,
         point_modifier=game_state.npc.point_modifier + npc_bonus,
         next_round_point_modifier=0,
+        conditional_point_modifier_non_wildcard=(
+            game_state.npc.conditional_point_modifier_non_wildcard
+            + game_state.npc.next_round_conditional_point_modifier_non_wildcard
+        ),
+        next_round_conditional_point_modifier_non_wildcard=0,
     )
 
     logs: list[str] = []

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -114,7 +114,9 @@ class PlayerState:
     draw_stock: list[Card] = field(default_factory=list)
     revealed_card_ids: frozenset[str] = frozenset()
     point_modifier: int = 0
+    conditional_point_modifier_non_wildcard: int = 0
     next_round_point_modifier: int = 0
+    next_round_conditional_point_modifier_non_wildcard: int = 0
     effect_negated: bool = False
 
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -531,14 +531,40 @@ def test_conditional_debuff_next_is_applied_only_on_next_round_for_npc_side():
     )
 
     state = resolve_round(state, other, subaru)
-    assert state.player.next_round_point_modifier == -3
+    assert state.player.next_round_conditional_point_modifier_non_wildcard == -3
     assert state.player.point_modifier == 0
 
     next_state = proceed_to_next(state)
     assert next_state.round_number == 2
-    assert next_state.player.point_modifier == -3
-    assert next_state.player.next_round_point_modifier == 0
+    assert next_state.player.conditional_point_modifier_non_wildcard == -3
+    assert next_state.player.next_round_conditional_point_modifier_non_wildcard == 0
 
     third_state = proceed_to_next(next_state)
     assert third_state.round_number == 3
     assert third_state.player.point_modifier == 0
+
+
+def test_conditional_debuff_next_does_not_apply_to_wildcard():
+    subaru = Card(
+        "c47",
+        "昴",
+        "すばる",
+        Janken.PAPER,
+        12,
+        Effect(EffectType.CONDITIONAL_DEBUFF_NEXT, "next -3", -3),
+    )
+    wildcard = Card("cw", "バー", "ばー", Janken.WILDCARD, 10, None)
+    player_card = Card("pr", "pr", "ぴーあーる", Janken.PAPER, 10, None)
+    npc_other = Card("n2", "n2", "えぬつー", Janken.ROCK, 5, None)
+    player_other = Card("p2", "p2", "ぴーつー", Janken.SCISSORS, 5, None)
+    state = GameState(
+        player=PlayerState(hand=[player_card, wildcard, player_other]),
+        npc=PlayerState(hand=[subaru, npc_other]),
+    )
+
+    state = resolve_round(state, player_card, subaru)
+    next_state = proceed_to_next(state)
+
+    assert next_state.player.conditional_point_modifier_non_wildcard == -3
+    assert next_state.player.point_modifier == 0
+    assert calculate_effective_point(wildcard, next_state.player) == wildcard.base_point

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -480,3 +480,65 @@ def test_takane_draw_reveals_both_remaining_hands_persistently():
 
     assert next_state.player.revealed_card_ids == frozenset({p_extra.id})
     assert next_state.npc.revealed_card_ids == frozenset({n_extra.id})
+
+
+def test_buff_next_is_applied_only_on_next_round_for_player_side():
+    iori = Card(
+        "c7",
+        "伊織",
+        "いおり",
+        Janken.ROCK,
+        10,
+        Effect(EffectType.BUFF_NEXT, "next +3", 3),
+    )
+    other = Card("cx", "other", "おざー", Janken.ROCK, 8, None)
+    extra_p = Card("p2", "p2", "ぴーつー", Janken.SCISSORS, 5, None)
+    extra_n = Card("n2", "n2", "えぬつー", Janken.PAPER, 5, None)
+    state = GameState(
+        player=PlayerState(hand=[iori, extra_p]),
+        npc=PlayerState(hand=[other, extra_n]),
+    )
+
+    state = resolve_round(state, iori, other)
+    assert state.player.next_round_point_modifier == 3
+    assert state.player.point_modifier == 0
+
+    next_state = proceed_to_next(state)
+    assert next_state.round_number == 2
+    assert next_state.player.point_modifier == 3
+    assert next_state.player.next_round_point_modifier == 0
+
+    third_state = proceed_to_next(next_state)
+    assert third_state.round_number == 3
+    assert third_state.player.point_modifier == 0
+
+
+def test_conditional_debuff_next_is_applied_only_on_next_round_for_npc_side():
+    subaru = Card(
+        "c47",
+        "昴",
+        "すばる",
+        Janken.PAPER,
+        12,
+        Effect(EffectType.CONDITIONAL_DEBUFF_NEXT, "next -3", -3),
+    )
+    other = Card("cx", "other", "おざー", Janken.PAPER, 12, None)
+    extra_p = Card("p2", "p2", "ぴーつー", Janken.SCISSORS, 5, None)
+    extra_n = Card("n2", "n2", "えぬつー", Janken.ROCK, 5, None)
+    state = GameState(
+        player=PlayerState(hand=[other, extra_p]),
+        npc=PlayerState(hand=[subaru, extra_n]),
+    )
+
+    state = resolve_round(state, other, subaru)
+    assert state.player.next_round_point_modifier == -3
+    assert state.player.point_modifier == 0
+
+    next_state = proceed_to_next(state)
+    assert next_state.round_number == 2
+    assert next_state.player.point_modifier == -3
+    assert next_state.player.next_round_point_modifier == 0
+
+    third_state = proceed_to_next(next_state)
+    assert third_state.round_number == 3
+    assert third_state.player.point_modifier == 0


### PR DESCRIPTION
## 概要
- `conditional_debuff_next` の「バー以外」条件を満たすよう修正
- `PlayerState` に条件付き補正の現在値/次ラウンド予約値を追加
- 次ラウンド開始時に条件付き補正を1回だけ適用して消費するように持ち越し処理を更新
- ポイント計算で `WILDCARD`（バー）には条件付き補正を適用しないよう修正
- テストを更新・追加し、次ラウンド1回適用とバー除外を検証

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest

Closes #7
