### PR TITLE
fix(engine): 制約下でのカード選択検証を厳格化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,12 @@ gh pr create \
   --title "feat(...): ..." \
   --body-file /tmp/pr_body.md
 ```
+
+### Codex 作業完了条件（必須）
+
+- Codex は、コード変更があり `git commit` した場合、**ユーザーから明示指示がなくても** `gh` コマンドで PR を作成して作業完了とする。
+- 原則として以下をこの順番で実施する:
+  1. `git push -u origin <branch>`（初回のみ `-u`）
+  2. `gh pr create -R ftnext/millionlive-shadow-bout --base main --head <branch> --title "<conventional commit準拠>" --body-file <file>`
+- 既存PRが同一ブランチにある場合は新規作成せず、追加コミットをpushしたうえで既存PRを更新対象とする。
+- 変更がない（コミットしない）場合は PR を作成しない。

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -286,10 +286,47 @@ def start_game(deck: list[Card]) -> GameState:
     return replace(state, phase=Phase.SELECT)
 
 
+def _is_playable_under_constraints(player_state: PlayerState, card: Card) -> bool:
+    if card.id in player_state.banned_card_ids:
+        return False
+    if (
+        player_state.forced_card_id is not None
+        and card.id != player_state.forced_card_id
+    ):
+        return False
+    return True
+
+
+def _validate_selected_card(player_state: PlayerState, card: Card, side: Side) -> None:
+    if not _is_playable_under_constraints(player_state, card):
+        if (
+            player_state.forced_card_id is not None
+            and card.id != player_state.forced_card_id
+        ):
+            raise ValueError(
+                f"{side.value} must play forced card: {player_state.forced_card_id}"
+            )
+        raise ValueError(f"{side.value} cannot play banned card: {card.id}")
+
+
+def _select_npc_card_with_constraints(
+    game_state: GameState, npc_strategy: NpcStrategy
+) -> Card:
+    constrained_hand = [
+        card
+        for card in game_state.npc.hand
+        if _is_playable_under_constraints(game_state.npc, card)
+    ]
+    if constrained_hand:
+        return npc_strategy.select_card(constrained_hand, game_state)
+    return npc_strategy.select_card(game_state.npc.hand, game_state)
+
+
 def select_card(
     game_state: GameState, player_card: Card, npc_strategy: NpcStrategy
 ) -> GameState:
-    npc_card = npc_strategy.select_card(game_state.npc.hand, game_state)
+    _validate_selected_card(game_state.player, player_card, Side.PLAYER)
+    npc_card = _select_npc_card_with_constraints(game_state, npc_strategy)
     return resolve_npc_pending_effects(
         resolve_round(game_state, player_card, npc_card), npc_strategy
     )
@@ -298,7 +335,8 @@ def select_card(
 def select_card_stepwise(
     game_state: GameState, player_card: Card, npc_strategy: NpcStrategy
 ) -> GameState:
-    npc_card = npc_strategy.select_card(game_state.npc.hand, game_state)
+    _validate_selected_card(game_state.player, player_card, Side.PLAYER)
+    npc_card = _select_npc_card_with_constraints(game_state, npc_strategy)
     return resolve_round_stepwise(game_state, player_card, npc_card)
 
 

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -297,7 +297,18 @@ def _is_playable_under_constraints(player_state: PlayerState, card: Card) -> boo
     return True
 
 
+def _selectable_cards_under_constraints(player_state: PlayerState) -> list[Card]:
+    return [
+        card
+        for card in player_state.hand
+        if _is_playable_under_constraints(player_state, card)
+    ]
+
+
 def _validate_selected_card(player_state: PlayerState, card: Card, side: Side) -> None:
+    if all(card.id != hand_card.id for hand_card in player_state.hand):
+        raise ValueError(f"{side.value} selected card is not in hand: {card.id}")
+
     if not _is_playable_under_constraints(player_state, card):
         if (
             player_state.forced_card_id is not None
@@ -312,14 +323,10 @@ def _validate_selected_card(player_state: PlayerState, card: Card, side: Side) -
 def _select_npc_card_with_constraints(
     game_state: GameState, npc_strategy: NpcStrategy
 ) -> Card:
-    constrained_hand = [
-        card
-        for card in game_state.npc.hand
-        if _is_playable_under_constraints(game_state.npc, card)
-    ]
-    if constrained_hand:
-        return npc_strategy.select_card(constrained_hand, game_state)
-    return npc_strategy.select_card(game_state.npc.hand, game_state)
+    constrained_hand = _selectable_cards_under_constraints(game_state.npc)
+    if not constrained_hand:
+        raise ValueError("npc has no playable cards under current constraints")
+    return npc_strategy.select_card(constrained_hand, game_state)
 
 
 def select_card(

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -118,6 +118,9 @@ class PlayerState:
     next_round_point_modifier: int = 0
     next_round_conditional_point_modifier_non_wildcard: int = 0
     effect_negated: bool = False
+    banned_card_ids: frozenset[str] = frozenset()
+    forced_card_id: str | None = None
+    must_reveal_played_card: bool = False
 
 
 @dataclass(frozen=True)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -7,6 +7,7 @@ from shadow_bout.engine import (
     init_game,
     judge_janken,
     proceed_to_next,
+    select_card,
 )
 from shadow_bout.models import (
     BattleResult,
@@ -30,6 +31,61 @@ def mock_cards():
         Card("c3", "P10", "kana", Janken.PAPER, 10),
         Card("c4", "R20", "kana", Janken.ROCK, 20),
     ]
+
+
+class FirstCardStrategy:
+    def select_card(self, hand, game_state):
+        return hand[0]
+
+
+def test_select_card_rejects_banned_player_card(mock_cards):
+    p1, p2, n1, _ = mock_cards
+    state = GameState(
+        player=PlayerState(hand=[p1, p2], banned_card_ids=frozenset({p1.id})),
+        npc=PlayerState(hand=[n1]),
+        phase=Phase.SELECT,
+    )
+
+    with pytest.raises(ValueError, match="cannot play banned card"):
+        select_card(state, p1, FirstCardStrategy())
+
+
+def test_select_card_rejects_non_forced_player_card(mock_cards):
+    p1, p2, n1, _ = mock_cards
+    state = GameState(
+        player=PlayerState(hand=[p1, p2], forced_card_id=p2.id),
+        npc=PlayerState(hand=[n1]),
+        phase=Phase.SELECT,
+    )
+
+    with pytest.raises(ValueError, match="must play forced card"):
+        select_card(state, p1, FirstCardStrategy())
+
+
+def test_select_card_applies_npc_forced_play(mock_cards):
+    p1, n1, n2, _ = mock_cards
+    state = GameState(
+        player=PlayerState(hand=[p1]),
+        npc=PlayerState(hand=[n1, n2], forced_card_id=n2.id),
+        phase=Phase.SELECT,
+    )
+
+    next_state = select_card(state, p1, FirstCardStrategy())
+
+    assert all(card.id != n2.id for card in next_state.npc.hand)
+
+
+def test_select_card_without_constraints_keeps_current_behavior(mock_cards):
+    p1, n1, _, _ = mock_cards
+    state = GameState(
+        player=PlayerState(hand=[p1]),
+        npc=PlayerState(hand=[n1]),
+        phase=Phase.SELECT,
+    )
+
+    next_state = select_card(state, p1, FirstCardStrategy())
+
+    assert next_state.phase == Phase.REVEAL
 
 
 def test_judge_janken(mock_cards):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -62,6 +62,18 @@ def test_select_card_rejects_non_forced_player_card(mock_cards):
         select_card(state, p1, FirstCardStrategy())
 
 
+def test_select_card_rejects_player_card_not_in_hand(mock_cards):
+    p1, p2, n1, _ = mock_cards
+    state = GameState(
+        player=PlayerState(hand=[p1]),
+        npc=PlayerState(hand=[n1]),
+        phase=Phase.SELECT,
+    )
+
+    with pytest.raises(ValueError, match="selected card is not in hand"):
+        select_card(state, p2, FirstCardStrategy())
+
+
 def test_select_card_applies_npc_forced_play(mock_cards):
     p1, n1, n2, _ = mock_cards
     state = GameState(
@@ -73,6 +85,18 @@ def test_select_card_applies_npc_forced_play(mock_cards):
     next_state = select_card(state, p1, FirstCardStrategy())
 
     assert all(card.id != n2.id for card in next_state.npc.hand)
+
+
+def test_select_card_rejects_when_npc_has_no_playable_card(mock_cards):
+    p1, n1, _, _ = mock_cards
+    state = GameState(
+        player=PlayerState(hand=[p1]),
+        npc=PlayerState(hand=[n1], banned_card_ids=frozenset({n1.id})),
+        phase=Phase.SELECT,
+    )
+
+    with pytest.raises(ValueError, match="npc has no playable cards"):
+        select_card(state, p1, FirstCardStrategy())
 
 
 def test_select_card_without_constraints_keeps_current_behavior(mock_cards):


### PR DESCRIPTION
## 概要
- `select_card` / `select_card_stepwise` の制約チェックを厳格化しました。
- プレイヤー選択カードが手札に存在しない場合は `ValueError`。
- NPC は制約を満たす候補からのみ選択し、候補0枚なら `ValueError` を返します（制約無視フォールバックを廃止）。
- テストを追加し、上記エラーケースを検証しました。

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
