### PR TITLE
fix(engine): model persistent effects with remaining_turns

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -272,6 +272,28 @@ def effect_conditional_debuff_next(
     )
 
 
+@register("debuff_persistent")
+def effect_debuff_persistent(state: GameState, side: Side, card: Card) -> GameState:
+    opp_side = get_opponent_side(side)
+    opp_state = get_player_state(state, opp_side)
+    debuff = int(card.effect.value or 0)
+    state = update_player(
+        state, opp_side, point_modifier=opp_state.point_modifier + debuff
+    )
+    # 「このターンと次のターン」: 現ターンは即時適用し、次ターン分を継続効果として保持
+    updated_opp_state = get_player_state(state, opp_side)
+    state = update_player(
+        state,
+        opp_side,
+        persistent_point_effects=updated_opp_state.persistent_point_effects + (debuff,),
+    )
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手のポイントをこのターンと次ターン{debuff:+d}"],
+    )
+
+
 @register("negate")
 def effect_negate(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -7,7 +7,14 @@ from shadow_bout.effect_utils import (
     get_player_state,
     update_player,
 )
-from shadow_bout.models import Card, GameState, PendingEffectContext, Phase, Side
+from shadow_bout.models import (
+    Card,
+    GameState,
+    PendingEffectContext,
+    PersistentPointEffect,
+    Phase,
+    Side,
+)
 
 EffectHandler = Callable[[GameState, Side, Card], GameState]
 _registry: dict[str, EffectHandler] = {}
@@ -285,7 +292,8 @@ def effect_debuff_persistent(state: GameState, side: Side, card: Card) -> GameSt
     state = update_player(
         state,
         opp_side,
-        persistent_point_effects=updated_opp_state.persistent_point_effects + (debuff,),
+        persistent_point_effects=updated_opp_state.persistent_point_effects
+        + (PersistentPointEffect(value=debuff, remaining_turns=1),),
     )
     return replace(
         state,

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -209,25 +209,32 @@ def apply_next_round_carryover_effects(game_state: GameState) -> GameState:
     player_bonus = game_state.player.next_round_point_modifier
     npc_bonus = game_state.npc.next_round_point_modifier
 
+    player_persistent_bonus = sum(game_state.player.persistent_point_effects)
+    npc_persistent_bonus = sum(game_state.npc.persistent_point_effects)
+
     new_player = replace(
         game_state.player,
-        point_modifier=game_state.player.point_modifier + player_bonus,
+        point_modifier=(
+            game_state.player.point_modifier + player_bonus + player_persistent_bonus
+        ),
         next_round_point_modifier=0,
         conditional_point_modifier_non_wildcard=(
             game_state.player.conditional_point_modifier_non_wildcard
             + game_state.player.next_round_conditional_point_modifier_non_wildcard
         ),
         next_round_conditional_point_modifier_non_wildcard=0,
+        persistent_point_effects=(),
     )
     new_npc = replace(
         game_state.npc,
-        point_modifier=game_state.npc.point_modifier + npc_bonus,
+        point_modifier=game_state.npc.point_modifier + npc_bonus + npc_persistent_bonus,
         next_round_point_modifier=0,
         conditional_point_modifier_non_wildcard=(
             game_state.npc.conditional_point_modifier_non_wildcard
             + game_state.npc.next_round_conditional_point_modifier_non_wildcard
         ),
         next_round_conditional_point_modifier_non_wildcard=0,
+        persistent_point_effects=(),
     )
 
     logs: list[str] = []
@@ -238,6 +245,14 @@ def apply_next_round_carryover_effects(game_state: GameState) -> GameState:
     if npc_bonus:
         logs.append(
             f"R{game_state.round_number}: 持ち越し効果適用 NPC ポイント{npc_bonus:+d}"
+        )
+    if player_persistent_bonus:
+        logs.append(
+            f"R{game_state.round_number}: 継続効果適用 あなた ポイント{player_persistent_bonus:+d}"
+        )
+    if npc_persistent_bonus:
+        logs.append(
+            f"R{game_state.round_number}: 継続効果適用 NPC ポイント{npc_persistent_bonus:+d}"
         )
 
     return replace(

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -209,8 +209,22 @@ def apply_next_round_carryover_effects(game_state: GameState) -> GameState:
     player_bonus = game_state.player.next_round_point_modifier
     npc_bonus = game_state.npc.next_round_point_modifier
 
-    player_persistent_bonus = sum(game_state.player.persistent_point_effects)
-    npc_persistent_bonus = sum(game_state.npc.persistent_point_effects)
+    player_persistent_bonus = sum(
+        effect.value for effect in game_state.player.persistent_point_effects
+    )
+    npc_persistent_bonus = sum(
+        effect.value for effect in game_state.npc.persistent_point_effects
+    )
+    player_remaining_effects = tuple(
+        replace(effect, remaining_turns=effect.remaining_turns - 1)
+        for effect in game_state.player.persistent_point_effects
+        if effect.remaining_turns > 1
+    )
+    npc_remaining_effects = tuple(
+        replace(effect, remaining_turns=effect.remaining_turns - 1)
+        for effect in game_state.npc.persistent_point_effects
+        if effect.remaining_turns > 1
+    )
 
     new_player = replace(
         game_state.player,
@@ -223,7 +237,7 @@ def apply_next_round_carryover_effects(game_state: GameState) -> GameState:
             + game_state.player.next_round_conditional_point_modifier_non_wildcard
         ),
         next_round_conditional_point_modifier_non_wildcard=0,
-        persistent_point_effects=(),
+        persistent_point_effects=player_remaining_effects,
     )
     new_npc = replace(
         game_state.npc,
@@ -234,7 +248,7 @@ def apply_next_round_carryover_effects(game_state: GameState) -> GameState:
             + game_state.npc.next_round_conditional_point_modifier_non_wildcard
         ),
         next_round_conditional_point_modifier_non_wildcard=0,
-        persistent_point_effects=(),
+        persistent_point_effects=npc_remaining_effects,
     )
 
     logs: list[str] = []

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -121,7 +121,13 @@ class PlayerState:
     banned_card_ids: frozenset[str] = frozenset()
     forced_card_id: str | None = None
     must_reveal_played_card: bool = False
-    persistent_point_effects: tuple[int, ...] = ()
+    persistent_point_effects: tuple["PersistentPointEffect", ...] = ()
+
+
+@dataclass(frozen=True)
+class PersistentPointEffect:
+    value: int
+    remaining_turns: int
 
 
 @dataclass(frozen=True)

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -121,6 +121,7 @@ class PlayerState:
     banned_card_ids: frozenset[str] = frozenset()
     forced_card_id: str | None = None
     must_reveal_played_card: bool = False
+    persistent_point_effects: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -14,6 +14,7 @@ from shadow_bout.models import (
     EffectType,
     GameState,
     Janken,
+    PersistentPointEffect,
     Phase,
     PlayerState,
     RoundOutcome,
@@ -589,7 +590,9 @@ def test_debuff_persistent_applies_current_and_next_round_only():
 
     state = resolve_round(state, player_card, hinata)
     assert state.player.point_modifier == -2
-    assert state.player.persistent_point_effects == (-2,)
+    assert state.player.persistent_point_effects == (
+        PersistentPointEffect(value=-2, remaining_turns=1),
+    )
 
     next_state = proceed_to_next(state)
     assert next_state.round_number == 2

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -568,3 +568,34 @@ def test_conditional_debuff_next_does_not_apply_to_wildcard():
     assert next_state.player.conditional_point_modifier_non_wildcard == -3
     assert next_state.player.point_modifier == 0
     assert calculate_effective_point(wildcard, next_state.player) == wildcard.base_point
+
+
+def test_debuff_persistent_applies_current_and_next_round_only():
+    hinata = Card(
+        "c35",
+        "ひなた",
+        "ひなた",
+        Janken.ROCK,
+        10,
+        Effect(EffectType.DEBUFF_PERSISTENT, "this and next -2", -2),
+    )
+    player_card = Card("p1", "p1", "ぴー1", Janken.ROCK, 10, None)
+    p_next = Card("p2", "p2", "ぴー2", Janken.PAPER, 10, None)
+    n_next = Card("n2", "n2", "えぬ2", Janken.SCISSORS, 10, None)
+    state = GameState(
+        player=PlayerState(hand=[player_card, p_next]),
+        npc=PlayerState(hand=[hinata, n_next]),
+    )
+
+    state = resolve_round(state, player_card, hinata)
+    assert state.player.point_modifier == -2
+    assert state.player.persistent_point_effects == (-2,)
+
+    next_state = proceed_to_next(state)
+    assert next_state.round_number == 2
+    assert next_state.player.point_modifier == -2
+    assert next_state.player.persistent_point_effects == ()
+
+    third_state = proceed_to_next(next_state)
+    assert third_state.round_number == 3
+    assert third_state.player.point_modifier == 0


### PR DESCRIPTION
## 概要
- Issue #11 の指摘に合わせ、継続効果の状態を `remaining_turns` を持つ構造へ変更
- `debuff_persistent` は発動ターン即時適用 + 次ターン分を継続効果として登録
- ラウンド遷移時に継続効果を適用し、`remaining_turns` をデクリメントして失効管理

## 変更詳細
- `PlayerState.persistent_point_effects` を `tuple[PersistentPointEffect, ...]` に変更
- `PersistentPointEffect(value, remaining_turns)` を追加
- `apply_next_round_carryover_effects` で継続効果の合算・デクリメント・残存判定を実施
- 対応テストを更新

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
