### PR TITLE
feat: add constraint state update helpers

### DIFF
--- a/shadow_bout/effect_utils.py
+++ b/shadow_bout/effect_utils.py
@@ -18,3 +18,26 @@ def get_player_state(state: GameState, side: Side) -> PlayerState:
 
 def get_opponent_side(side: Side) -> Side:
     return Side.NPC if side == Side.PLAYER else Side.PLAYER
+
+
+def add_banned_card_id(state: GameState, side: Side, card_id: str) -> GameState:
+    player_state = get_player_state(state, side)
+    return update_player(
+        state,
+        side,
+        banned_card_ids=player_state.banned_card_ids | {card_id},
+    )
+
+
+def set_forced_card_id(state: GameState, side: Side, card_id: str | None) -> GameState:
+    return update_player(state, side, forced_card_id=card_id)
+
+
+def clear_forced_card_id(state: GameState, side: Side) -> GameState:
+    return set_forced_card_id(state, side, None)
+
+
+def set_must_reveal_played_card(
+    state: GameState, side: Side, should_reveal: bool
+) -> GameState:
+    return update_player(state, side, must_reveal_played_card=should_reveal)

--- a/tests/test_effect_utils.py
+++ b/tests/test_effect_utils.py
@@ -1,0 +1,36 @@
+from shadow_bout.effect_utils import (
+    add_banned_card_id,
+    clear_forced_card_id,
+    set_forced_card_id,
+    set_must_reveal_played_card,
+)
+from shadow_bout.models import GameState, PlayerState, Side
+
+
+def test_add_banned_card_id_updates_only_target_side() -> None:
+    state = GameState(player=PlayerState(), npc=PlayerState())
+
+    next_state = add_banned_card_id(state, Side.PLAYER, "card-001")
+
+    assert next_state.player.banned_card_ids == frozenset({"card-001"})
+    assert next_state.npc.banned_card_ids == frozenset()
+
+
+def test_set_and_clear_forced_card_id() -> None:
+    state = GameState(player=PlayerState(), npc=PlayerState())
+
+    forced_state = set_forced_card_id(state, Side.NPC, "card-777")
+    assert forced_state.npc.forced_card_id == "card-777"
+
+    cleared_state = clear_forced_card_id(forced_state, Side.NPC)
+    assert cleared_state.npc.forced_card_id is None
+
+
+def test_set_must_reveal_played_card() -> None:
+    state = GameState(player=PlayerState(), npc=PlayerState())
+
+    reveal_state = set_must_reveal_played_card(state, Side.PLAYER, True)
+    assert reveal_state.player.must_reveal_played_card is True
+
+    hidden_state = set_must_reveal_played_card(reveal_state, Side.PLAYER, False)
+    assert hidden_state.player.must_reveal_played_card is False


### PR DESCRIPTION
## 概要
- 制約状態（ban / force / curse）を更新する共通ヘルパーを `shadow_bout.effect_utils` に追加
- ban追加、forced設定/解除、must_reveal設定のAPIを実装
- 新規テストを追加し、対象サイドのみ更新されることを確認

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
