### PR TITLE
feat(effects): implement force_play handler

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -313,6 +313,26 @@ def effect_negate(state: GameState, side: Side, card: Card) -> GameState:
     )
 
 
+@register("force_play")
+def effect_force_play(state: GameState, side: Side, card: Card) -> GameState:
+    opp_side = get_opponent_side(side)
+    opp_state = get_player_state(state, opp_side)
+    if not opp_state.hand:
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手の手札がないため不発"],
+        )
+
+    target = random.choice(opp_state.hand)
+    state = update_player(state, opp_side, forced_card_id=target.id)
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手は次ラウンドで{target.name}を強制プレイ"],
+    )
+
+
 @register("reveal")
 def effect_reveal(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -283,10 +283,20 @@ def set_battle_cards_as_played(
     new_player = replace(
         game_state.player,
         hand=[card for card in game_state.player.hand if card.id != player_card.id],
+        forced_card_id=(
+            None
+            if game_state.player.forced_card_id == player_card.id
+            else game_state.player.forced_card_id
+        ),
     )
     new_npc = replace(
         game_state.npc,
         hand=[card for card in game_state.npc.hand if card.id != npc_card.id],
+        forced_card_id=(
+            None
+            if game_state.npc.forced_card_id == npc_card.id
+            else game_state.npc.forced_card_id
+        ),
     )
     return replace(game_state, player=new_player, npc=new_npc)
 
@@ -318,10 +328,10 @@ def start_game(deck: list[Card]) -> GameState:
 def _is_playable_under_constraints(player_state: PlayerState, card: Card) -> bool:
     if card.id in player_state.banned_card_ids:
         return False
-    if (
-        player_state.forced_card_id is not None
-        and card.id != player_state.forced_card_id
-    ):
+    has_forced_card_in_hand = player_state.forced_card_id is not None and any(
+        hand_card.id == player_state.forced_card_id for hand_card in player_state.hand
+    )
+    if has_forced_card_in_hand and card.id != player_state.forced_card_id:
         return False
     return True
 

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -283,20 +283,12 @@ def set_battle_cards_as_played(
     new_player = replace(
         game_state.player,
         hand=[card for card in game_state.player.hand if card.id != player_card.id],
-        forced_card_id=(
-            None
-            if game_state.player.forced_card_id == player_card.id
-            else game_state.player.forced_card_id
-        ),
+        forced_card_id=None,
     )
     new_npc = replace(
         game_state.npc,
         hand=[card for card in game_state.npc.hand if card.id != npc_card.id],
-        forced_card_id=(
-            None
-            if game_state.npc.forced_card_id == npc_card.id
-            else game_state.npc.forced_card_id
-        ),
+        forced_card_id=None,
     )
     return replace(game_state, player=new_player, npc=new_npc)
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -602,3 +602,65 @@ def test_debuff_persistent_applies_current_and_next_round_only():
     third_state = proceed_to_next(next_state)
     assert third_state.round_number == 3
     assert third_state.player.point_modifier == 0
+
+
+def test_force_play_sets_forced_card_id_on_opponent_side():
+    tamaki = Card(
+        "c12",
+        "環",
+        "たまき",
+        Janken.ROCK,
+        13,
+        Effect(EffectType.FORCE_PLAY, "force play", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.ROCK, 13, None)
+    n_extra = Card("n_extra", "n_extra", "ん", Janken.PAPER, 1)
+    state = GameState(
+        player=PlayerState(hand=[tamaki]),
+        npc=PlayerState(hand=[other, n_extra]),
+    )
+
+    state = resolve_round(state, tamaki, other)
+
+    assert state.npc.forced_card_id == n_extra.id
+
+
+def test_npc_force_play_sets_forced_card_id_on_player_side():
+    tamaki = Card(
+        "c12",
+        "環",
+        "たまき",
+        Janken.ROCK,
+        13,
+        Effect(EffectType.FORCE_PLAY, "force play", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.ROCK, 13, None)
+    p_extra = Card("p_extra", "p_extra", "ぴ", Janken.SCISSORS, 1)
+    state = GameState(
+        player=PlayerState(hand=[other, p_extra]),
+        npc=PlayerState(hand=[tamaki]),
+    )
+
+    state = resolve_round(state, other, tamaki)
+
+    assert state.player.forced_card_id == p_extra.id
+
+
+def test_force_play_is_safe_when_opponent_has_no_hand():
+    tamaki = Card(
+        "c12",
+        "環",
+        "たまき",
+        Janken.ROCK,
+        13,
+        Effect(EffectType.FORCE_PLAY, "force play", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.ROCK, 13, None)
+    state = GameState(
+        player=PlayerState(hand=[tamaki]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, tamaki, other)
+
+    assert state.npc.forced_card_id is None

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -99,6 +99,7 @@ def test_select_card_allows_play_when_forced_card_is_no_longer_in_hand(mock_card
     next_state = select_card(state, p1, FirstCardStrategy())
 
     assert next_state.phase == Phase.REVEAL
+    assert next_state.player.forced_card_id is None
 
 
 def test_select_card_rejects_when_npc_has_no_playable_card(mock_cards):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -85,6 +85,20 @@ def test_select_card_applies_npc_forced_play(mock_cards):
     next_state = select_card(state, p1, FirstCardStrategy())
 
     assert all(card.id != n2.id for card in next_state.npc.hand)
+    assert next_state.npc.forced_card_id is None
+
+
+def test_select_card_allows_play_when_forced_card_is_no_longer_in_hand(mock_cards):
+    p1, p2, n1, _ = mock_cards
+    state = GameState(
+        player=PlayerState(hand=[p1, p2], forced_card_id="missing-card-id"),
+        npc=PlayerState(hand=[n1]),
+        phase=Phase.SELECT,
+    )
+
+    next_state = select_card(state, p1, FirstCardStrategy())
+
+    assert next_state.phase == Phase.REVEAL
 
 
 def test_select_card_rejects_when_npc_has_no_playable_card(mock_cards):


### PR DESCRIPTION
## 概要
- `force_play` 効果を `effect_handlers` に実装し、相手手札からランダム1枚を `forced_card_id` に設定する処理を追加
- 相手手札が空のときは例外を出さず不発ログを残す安全動作を追加
- player/NPC 双方での強制プレイ設定と不発ケースを検証するテストを追加

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
