### PR TITLE
feat: implement ban effect and forced-card conflict rule

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -3,6 +3,8 @@ from dataclasses import replace
 from typing import Callable
 
 from shadow_bout.effect_utils import (
+    add_banned_card_id,
+    clear_forced_card_id,
     get_opponent_side,
     get_player_state,
     update_player,
@@ -330,6 +332,37 @@ def effect_force_play(state: GameState, side: Side, card: Card) -> GameState:
         state,
         battle_log=state.battle_log
         + [f"{card.name}の効果発動: 相手は次ラウンドで{target.name}を強制プレイ"],
+    )
+
+
+@register("ban")
+def effect_ban(state: GameState, side: Side, card: Card) -> GameState:
+    opp_side = get_opponent_side(side)
+    opp_state = get_player_state(state, opp_side)
+    if not opp_state.hand:
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手の手札がないため不発"],
+        )
+
+    target = random.choice(opp_state.hand)
+    state = add_banned_card_id(state, opp_side, target.id)
+
+    if opp_state.forced_card_id == target.id:
+        state = clear_forced_card_id(state, opp_side)
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [
+                f"{card.name}の効果発動: 相手の{target.name}を使用禁止（強制プレイは解除）"
+            ],
+        )
+
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手の{target.name}を使用禁止"],
     )
 
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -664,3 +664,46 @@ def test_force_play_is_safe_when_opponent_has_no_hand():
     state = resolve_round(state, tamaki, other)
 
     assert state.npc.forced_card_id is None
+
+
+def test_ban_adds_banned_card_id_on_opponent_side():
+    kaori = Card(
+        "card_52",
+        "歌織",
+        "かおり",
+        Janken.ROCK,
+        14,
+        Effect(EffectType.BAN, "ban", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.ROCK, 13, None)
+    n_extra = Card("n_extra", "n_extra", "ん", Janken.PAPER, 1)
+    state = GameState(
+        player=PlayerState(hand=[kaori]),
+        npc=PlayerState(hand=[other, n_extra]),
+    )
+
+    state = resolve_round(state, kaori, other)
+
+    assert state.npc.banned_card_ids == frozenset({n_extra.id})
+
+
+def test_ban_clears_forced_card_id_when_target_is_forced_card():
+    kaori = Card(
+        "card_52",
+        "歌織",
+        "かおり",
+        Janken.ROCK,
+        14,
+        Effect(EffectType.BAN, "ban", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.ROCK, 13, None)
+    forced = Card("forced", "forced", "ふぉーす", Janken.PAPER, 1)
+    state = GameState(
+        player=PlayerState(hand=[kaori]),
+        npc=PlayerState(hand=[other, forced], forced_card_id=forced.id),
+    )
+
+    state = resolve_round(state, kaori, other)
+
+    assert state.npc.banned_card_ids == frozenset({forced.id})
+    assert state.npc.forced_card_id is None


### PR DESCRIPTION
## 概要
- `ban` 効果（card_52）を実装し、相手手札から対象カードを1枚選んで `banned_card_ids` に追加するようにしました。
- ban 対象が `forced_card_id` と衝突した場合は **ban優先で forced を解除** する仕様を実装しました。
- 上記の挙動を検証するテストを追加しました。

## テスト
- .venv/bin/python -m pytest
- ruff format
- ruff check --fix --extend-select I
