### PR TITLE
feat(effect): curseで公開制約状態を付与

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -7,6 +7,7 @@ from shadow_bout.effect_utils import (
     clear_forced_card_id,
     get_opponent_side,
     get_player_state,
+    set_must_reveal_played_card,
     update_player,
 )
 from shadow_bout.models import (
@@ -525,4 +526,15 @@ def effect_removal(state: GameState, side: Side, card: Card) -> GameState:
     )
     return replace(
         state, battle_log=state.battle_log + [f"{card.name}の効果発動: 発動待機中..."]
+    )
+
+
+@register("curse")
+def effect_curse(state: GameState, side: Side, card: Card) -> GameState:
+    opp_side = get_opponent_side(side)
+    state = set_must_reveal_played_card(state, opp_side, True)
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手の次の出し札を公開"],
     )

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -293,6 +293,28 @@ def set_battle_cards_as_played(
     return replace(game_state, player=new_player, npc=new_npc)
 
 
+def apply_must_reveal_played_card(
+    game_state: GameState, player_card: Card, npc_card: Card
+) -> GameState:
+    revealed_cards: list[Card] = []
+    revealed_side: Side | None = None
+
+    if game_state.player.must_reveal_played_card:
+        revealed_cards.append(player_card)
+        revealed_side = Side.PLAYER
+    if game_state.npc.must_reveal_played_card:
+        revealed_cards.append(npc_card)
+        revealed_side = Side.NPC if revealed_side is None else None
+
+    return replace(
+        game_state,
+        player=replace(game_state.player, must_reveal_played_card=False),
+        npc=replace(game_state.npc, must_reveal_played_card=False),
+        revealed_this_round=revealed_cards or None,
+        revealed_this_round_side=revealed_side,
+    )
+
+
 def init_game(deck: list[Card]) -> GameState:
     """デッキをシャッフルし、手札5枚を配布した GameState を返す。"""
     p_deck = list(deck)
@@ -382,6 +404,7 @@ def resolve_round(
     game_state: GameState, player_card: Card, npc_card: Card
 ) -> GameState:
     game_state = set_battle_cards_as_played(game_state, player_card, npc_card)
+    game_state = apply_must_reveal_played_card(game_state, player_card, npc_card)
     j_res = judge_janken(player_card, npc_card)
 
     player_point = None
@@ -456,6 +479,7 @@ def resolve_round_stepwise(
     game_state: GameState, player_card: Card, npc_card: Card
 ) -> GameState:
     game_state = set_battle_cards_as_played(game_state, player_card, npc_card)
+    game_state = apply_must_reveal_played_card(game_state, player_card, npc_card)
     j_res = judge_janken(player_card, npc_card)
 
     player_point = None

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -320,6 +320,26 @@ def test_mizuki_buff_dynamic_counts_remaining_hand_only():
     assert state.current_battle.outcome == RoundOutcome.WIN
 
 
+def test_curse_sets_must_reveal_state_on_opponent():
+    curse = Card(
+        "c51",
+        "呪い",
+        "のろい",
+        Janken.ROCK,
+        10,
+        Effect(EffectType.CURSE, "curse", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.ROCK, 9, None)
+    state = GameState(
+        player=PlayerState(hand=[curse]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, curse, other)
+
+    assert state.npc.must_reveal_played_card is True
+
+
 def test_ami_restart_does_not_duplicate_played_cards():
     ami = Card(
         "c11",

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -7,6 +7,7 @@ from shadow_bout.engine import (
     init_game,
     judge_janken,
     proceed_to_next,
+    resolve_round,
     select_card,
 )
 from shadow_bout.models import (
@@ -271,6 +272,21 @@ def test_proceed_to_next_resets_round_local_state(mock_cards):
     assert new_state.npc.point_modifier == 0
     assert new_state.npc.effect_negated is False
     assert new_state.npc.revealed_card_ids == frozenset({p_card.id})
+
+
+def test_resolve_round_consumes_must_reveal_played_card_and_records_reveal(mock_cards):
+    p1, n1, _, _ = mock_cards
+    state = GameState(
+        player=PlayerState(hand=[p1]),
+        npc=PlayerState(hand=[n1], must_reveal_played_card=True),
+        phase=Phase.SELECT,
+    )
+
+    next_state = resolve_round(state, p1, n1)
+
+    assert next_state.npc.must_reveal_played_card is False
+    assert next_state.revealed_this_round == [n1]
+    assert next_state.revealed_this_round_side == Side.NPC
 
 
 def test_proceed_to_next_resolves_remaining_forfeit_rounds(mock_cards):


### PR DESCRIPTION
## 概要
- `curse` 効果ハンドラを追加し、効果発動時に相手へ `must_reveal_played_card` 制約状態を付与
- 効果発動ログを追加
- `curse` 発動後に対象側へ公開制約が残ることを確認するテストを追加

## テスト
- .venv/bin/python -m pytest
- ruff format
- ruff check --fix --extend-select I
