### PR TITLE
refactor(effect): split choose flow by card id for yuriko and karen

### DIFF
--- a/app.py
+++ b/app.py
@@ -228,7 +228,7 @@ def render_pending_effect_form(game_state):
     player = game_state.player
 
     if ctx.effect == "choose":
-        if ctx.step == 1:
+        if ctx.card_id in ("card_26", "c26") and ctx.step == 1:
             return_count = int(ctx.payload.get("return_count", 0))
             options, labels = card_id_options(player.hand)
             selected = st.multiselect(
@@ -250,17 +250,37 @@ def render_pending_effect_form(game_state):
                 submit_effect_choice(game_state, ",".join(selected))
             return
 
-        choice = st.radio(
-            "百合子の効果",
-            ["buff", "draw"],
-            format_func=lambda value: {
-                "buff": "自分のポイント+3",
-                "draw": "山札から2枚引き、手札2枚を山札の下へ戻す",
-            }[value],
-            horizontal=True,
-        )
-        if st.button("この効果を発動", type="primary", use_container_width=True):
-            submit_effect_choice(game_state, choice)
+        if ctx.card_id in ("card_26", "c26"):
+            choice = st.radio(
+                "百合子の効果",
+                ["gain_points", "draw_cards"],
+                format_func=lambda value: {
+                    "gain_points": "自分のポイント+3",
+                    "draw_cards": "山札から2枚引き、手札2枚を山札の下へ戻す",
+                }[value],
+                horizontal=True,
+            )
+            if st.button("この効果を発動", type="primary", use_container_width=True):
+                submit_effect_choice(game_state, choice)
+            return
+
+        if ctx.card_id in ("card_45", "c45"):
+            choice = st.radio(
+                "可憐の効果",
+                ["activate", "skip"],
+                format_func=lambda value: {
+                    "activate": "発動する（相手の公開を2ラウンド強制）",
+                    "skip": "発動しない",
+                }[value],
+                horizontal=True,
+            )
+            if st.button("この効果を決定", type="primary", use_container_width=True):
+                submit_effect_choice(game_state, choice)
+            return
+
+        st.info("このカードの選択効果には未対応です。")
+        if st.button("次へ", type="primary", use_container_width=True):
+            submit_effect_choice(game_state, None)
         return
 
     if ctx.effect == "copy_hand":

--- a/app.py
+++ b/app.py
@@ -228,7 +228,8 @@ def render_pending_effect_form(game_state):
     player = game_state.player
 
     if ctx.effect == "choose":
-        if ctx.card_id in ("card_26", "c26") and ctx.step == 1:
+        variant = ctx.payload.get("choose_variant")
+        if variant == "yuriko_return_cards" and ctx.step == 1:
             return_count = int(ctx.payload.get("return_count", 0))
             options, labels = card_id_options(player.hand)
             selected = st.multiselect(
@@ -250,7 +251,7 @@ def render_pending_effect_form(game_state):
                 submit_effect_choice(game_state, ",".join(selected))
             return
 
-        if ctx.card_id in ("card_26", "c26"):
+        if variant == "yuriko_choose":
             choice = st.radio(
                 "百合子の効果",
                 ["gain_points", "draw_cards"],
@@ -264,7 +265,7 @@ def render_pending_effect_form(game_state):
                 submit_effect_choice(game_state, choice)
             return
 
-        if ctx.card_id in ("card_45", "c45"):
+        if variant == "karen_choose":
             choice = st.radio(
                 "可憐の効果",
                 ["activate", "skip"],

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -8,6 +8,7 @@ from shadow_bout.effect_utils import (
     get_opponent_side,
     get_player_state,
     set_must_reveal_played_card,
+    set_must_reveal_played_card_rounds,
     update_player,
 )
 from shadow_bout.models import (
@@ -125,9 +126,10 @@ def _resume_choose(state: GameState, side: Side, choice: str | None) -> GameStat
     if variant == "karen_choose":
         if choice != "activate":
             return _finish_interactive_effect(state, "-> 可憐の効果: 発動しない")
-        state = set_must_reveal_played_card(state, get_opponent_side(side), True)
+        opp_side = get_opponent_side(side)
+        state = set_must_reveal_played_card_rounds(state, opp_side, rounds=2)
         return _finish_interactive_effect(
-            state, "-> 可憐の効果: 相手の次の出し札を公開"
+            state, "-> 可憐の効果: 相手は2ラウンドの間、出し札を公開"
         )
 
     return _finish_interactive_effect(state, "-> 選択効果: 未対応カード")

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -58,58 +58,78 @@ def _parse_card_ids(choice: str | None) -> list[str]:
 
 def _resume_choose(state: GameState, side: Side, choice: str | None) -> GameState:
     ctx = state.pending_effect_context
+    if ctx is None:
+        return state
     p_state = get_player_state(state, side)
-    if ctx and ctx.step == 1:
-        return_count = int(ctx.payload.get("return_count", 0))
-        selected_ids = _parse_card_ids(choice)
-        returned = [
-            card
-            for card_id in selected_ids
-            if (card := _find_card(p_state.hand, card_id))
-        ][:return_count]
+    if ctx.card_id in ("card_26", "c26"):
+        if ctx.step == 1:
+            return_count = int(ctx.payload.get("return_count", 0))
+            selected_ids = _parse_card_ids(choice)
+            returned = [
+                card
+                for card_id in selected_ids
+                if (card := _find_card(p_state.hand, card_id))
+            ][:return_count]
 
-        if len(returned) < return_count:
+            if len(returned) < return_count:
+                returned_ids = {card.id for card in returned}
+                returned.extend(
+                    card for card in p_state.hand if card.id not in returned_ids
+                )
+                returned = returned[:return_count]
+
             returned_ids = {card.id for card in returned}
-            returned.extend(
-                card for card in p_state.hand if card.id not in returned_ids
-            )
-            returned = returned[:return_count]
-
-        returned_ids = {card.id for card in returned}
-        new_hand = [card for card in p_state.hand if card.id not in returned_ids]
-        new_deck = p_state.deck + returned
-        state = update_player(state, side, hand=new_hand, deck=new_deck)
-        return _finish_interactive_effect(
-            state, "-> 百合子の効果: 山札から2枚引き、2枚を山札の下へ戻した"
-        )
-
-    if choice == "draw":
-        drawn = p_state.deck[:2]
-        new_deck = p_state.deck[2:]
-        new_hand = p_state.hand + drawn
-        state = update_player(state, side, hand=new_hand, deck=new_deck)
-        return_count = min(2, len(new_hand))
-        if return_count == 0:
+            new_hand = [card for card in p_state.hand if card.id not in returned_ids]
+            new_deck = p_state.deck + returned
+            state = update_player(state, side, hand=new_hand, deck=new_deck)
             return _finish_interactive_effect(
                 state,
-                "-> 百合子の効果: 山札からカードを引けず、戻す手札もなかった",
+                "-> 百合子の効果: 山札から2枚引き、2枚を山札の下へ戻した",
             )
 
-        next_ctx = replace(
-            ctx,
-            step=1,
-            payload={"return_count": return_count, "drawn_ids": [c.id for c in drawn]},
-        )
-        return replace(
-            state,
-            phase=Phase.INTERACTIVE_EFFECT,
-            pending_effect_context=next_ctx,
-            battle_log=state.battle_log
-            + [f"-> 百合子の効果: 山札から{len(drawn)}枚引いた。戻す手札を選択中..."],
+        if choice == "draw_cards":
+            drawn = p_state.deck[:2]
+            new_deck = p_state.deck[2:]
+            new_hand = p_state.hand + drawn
+            state = update_player(state, side, hand=new_hand, deck=new_deck)
+            return_count = min(2, len(new_hand))
+            if return_count == 0:
+                return _finish_interactive_effect(
+                    state,
+                    "-> 百合子の効果: 山札からカードを引けず、戻す手札もなかった",
+                )
+
+            next_ctx = replace(
+                ctx,
+                step=1,
+                payload={
+                    "choose_variant": "yuriko_return_cards",
+                    "return_count": return_count,
+                    "drawn_ids": [c.id for c in drawn],
+                },
+            )
+            return replace(
+                state,
+                phase=Phase.INTERACTIVE_EFFECT,
+                pending_effect_context=next_ctx,
+                battle_log=state.battle_log
+                + [
+                    f"-> 百合子の効果: 山札から{len(drawn)}枚引いた。戻す手札を選択中..."
+                ],
+            )
+
+        state = update_player(state, side, point_modifier=p_state.point_modifier + 3)
+        return _finish_interactive_effect(state, "-> 百合子の効果: ポイント+3")
+
+    if ctx.card_id in ("card_45", "c45"):
+        if choice != "activate":
+            return _finish_interactive_effect(state, "-> 可憐の効果: 発動しない")
+        state = set_must_reveal_played_card(state, get_opponent_side(side), rounds=2)
+        return _finish_interactive_effect(
+            state, "-> 可憐の効果: 相手は2ラウンドの間、出した戦具の公開が必須"
         )
 
-    state = update_player(state, side, point_modifier=p_state.point_modifier + 3)
-    return _finish_interactive_effect(state, "-> 百合子の効果: ポイント+3")
+    return _finish_interactive_effect(state, "-> 選択効果: 未対応カード")
 
 
 def _resume_copy_hand(state: GameState, side: Side, choice: str | None) -> GameState:
@@ -442,7 +462,18 @@ def effect_restart(state: GameState, side: Side, card: Card) -> GameState:
 
 @register("choose")
 def effect_choose(state: GameState, side: Side, card: Card) -> GameState:
-    ctx = PendingEffectContext(side=side, card_id=card.id, effect="choose")
+    choose_variant = {
+        "card_26": "yuriko_choose",
+        "c26": "yuriko_choose",
+        "card_45": "karen_choose",
+        "c45": "karen_choose",
+    }.get(card.id, "generic_choose")
+    ctx = PendingEffectContext(
+        side=side,
+        card_id=card.id,
+        effect="choose",
+        payload={"choose_variant": choose_variant},
+    )
     state = replace(
         state, phase=Phase.INTERACTIVE_EFFECT, effect_step=0, pending_effect_context=ctx
     )

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -61,7 +61,8 @@ def _resume_choose(state: GameState, side: Side, choice: str | None) -> GameStat
     if ctx is None:
         return state
     p_state = get_player_state(state, side)
-    if ctx.card_id in ("card_26", "c26"):
+    variant = ctx.payload.get("choose_variant")
+    if variant in ("yuriko_choose", "yuriko_return_cards"):
         if ctx.step == 1:
             return_count = int(ctx.payload.get("return_count", 0))
             selected_ids = _parse_card_ids(choice)
@@ -121,7 +122,7 @@ def _resume_choose(state: GameState, side: Side, choice: str | None) -> GameStat
         state = update_player(state, side, point_modifier=p_state.point_modifier + 3)
         return _finish_interactive_effect(state, "-> 百合子の効果: ポイント+3")
 
-    if ctx.card_id in ("card_45", "c45"):
+    if variant == "karen_choose":
         if choice != "activate":
             return _finish_interactive_effect(state, "-> 可憐の効果: 発動しない")
         state = set_must_reveal_played_card(state, get_opponent_side(side), rounds=2)

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -125,9 +125,9 @@ def _resume_choose(state: GameState, side: Side, choice: str | None) -> GameStat
     if variant == "karen_choose":
         if choice != "activate":
             return _finish_interactive_effect(state, "-> 可憐の効果: 発動しない")
-        state = set_must_reveal_played_card(state, get_opponent_side(side), rounds=2)
+        state = set_must_reveal_played_card(state, get_opponent_side(side), True)
         return _finish_interactive_effect(
-            state, "-> 可憐の効果: 相手は2ラウンドの間、出した戦具の公開が必須"
+            state, "-> 可憐の効果: 相手の次の出し札を公開"
         )
 
     return _finish_interactive_effect(state, "-> 選択効果: 未対応カード")

--- a/shadow_bout/effect_utils.py
+++ b/shadow_bout/effect_utils.py
@@ -41,3 +41,13 @@ def set_must_reveal_played_card(
     state: GameState, side: Side, should_reveal: bool
 ) -> GameState:
     return update_player(state, side, must_reveal_played_card=should_reveal)
+
+
+def set_must_reveal_played_card_rounds(
+    state: GameState, side: Side, rounds: int
+) -> GameState:
+    return update_player(
+        state,
+        side,
+        must_reveal_played_card_rounds=max(0, rounds),
+    )

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -627,14 +627,15 @@ def _choose_npc_pending_effect(
     source_card = _find_card_by_id(state, ctx.card_id)
 
     if ctx.effect == "choose":
+        variant = ctx.payload.get("choose_variant")
         if ctx.step == 1:
             return_count = int(ctx.payload.get("return_count", 0))
             return ",".join(
                 _select_npc_card_ids(npc.hand, return_count, state, npc_strategy)
             )
-        if ctx.card_id in ("card_26", "c26"):
+        if variant == "yuriko_choose":
             return npc_strategy.choose_effect(["gain_points", "draw_cards"], state)
-        if ctx.card_id in ("card_45", "c45"):
+        if variant == "karen_choose":
             if source_card and npc_strategy.should_activate(source_card, state):
                 return "activate"
             return "skip"

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -632,7 +632,13 @@ def _choose_npc_pending_effect(
             return ",".join(
                 _select_npc_card_ids(npc.hand, return_count, state, npc_strategy)
             )
-        return npc_strategy.choose_effect(["buff", "draw"], state)
+        if ctx.card_id in ("card_26", "c26"):
+            return npc_strategy.choose_effect(["gain_points", "draw_cards"], state)
+        if ctx.card_id in ("card_45", "c45"):
+            if source_card and npc_strategy.should_activate(source_card, state):
+                return "activate"
+            return "skip"
+        return None
 
     if ctx.effect == "copy_hand":
         candidates = [

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -299,17 +299,38 @@ def apply_must_reveal_played_card(
     revealed_cards: list[Card] = []
     revealed_side: Side | None = None
 
-    if game_state.player.must_reveal_played_card:
+    player_must_reveal = (
+        game_state.player.must_reveal_played_card
+        or game_state.player.must_reveal_played_card_rounds > 0
+    )
+    npc_must_reveal = (
+        game_state.npc.must_reveal_played_card
+        or game_state.npc.must_reveal_played_card_rounds > 0
+    )
+
+    if player_must_reveal:
         revealed_cards.append(player_card)
         revealed_side = Side.PLAYER
-    if game_state.npc.must_reveal_played_card:
+    if npc_must_reveal:
         revealed_cards.append(npc_card)
         revealed_side = Side.NPC if revealed_side is None else None
 
     return replace(
         game_state,
-        player=replace(game_state.player, must_reveal_played_card=False),
-        npc=replace(game_state.npc, must_reveal_played_card=False),
+        player=replace(
+            game_state.player,
+            must_reveal_played_card=False,
+            must_reveal_played_card_rounds=max(
+                game_state.player.must_reveal_played_card_rounds - 1, 0
+            ),
+        ),
+        npc=replace(
+            game_state.npc,
+            must_reveal_played_card=False,
+            must_reveal_played_card_rounds=max(
+                game_state.npc.must_reveal_played_card_rounds - 1, 0
+            ),
+        ),
         revealed_this_round=revealed_cards or None,
         revealed_this_round_side=revealed_side,
     )

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -121,6 +121,7 @@ class PlayerState:
     banned_card_ids: frozenset[str] = frozenset()
     forced_card_id: str | None = None
     must_reveal_played_card: bool = False
+    must_reveal_played_card_rounds: int = 0
     persistent_point_effects: tuple["PersistentPointEffect", ...] = ()
 
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -126,7 +126,7 @@ def test_resume_choose_effect_finalizes_round_with_buff():
     state = resolve_round(state, yuriko, other)
     assert state.phase == Phase.INTERACTIVE_EFFECT
 
-    state = resume_round_effect(state, choice="buff")
+    state = resume_round_effect(state, choice="gain_points")
 
     assert state.phase == Phase.REVEAL
     assert state.current_battle.player_point == 18
@@ -175,7 +175,7 @@ def test_stepwise_nested_copy_hand_choose_finalizes_points_after_last_choice():
     state = continue_round_effect_step(state)
     state = resume_round_effect_stepwise(state, choice=yuriko.id)
     state = continue_round_effect_step(state)
-    state = resume_round_effect_stepwise(state, choice="buff")
+    state = resume_round_effect_stepwise(state, choice="gain_points")
 
     assert state.phase == Phase.REVEAL
     assert state.current_battle.player_point == 20
@@ -204,7 +204,7 @@ def test_resume_choose_effect_draw_lets_player_select_returned_cards():
     )
 
     state = resolve_round(state, yuriko, other)
-    state = resume_round_effect(state, choice="draw")
+    state = resume_round_effect(state, choice="draw_cards")
 
     assert state.phase == Phase.INTERACTIVE_EFFECT
     assert state.pending_effect_context.side == Side.PLAYER

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -340,6 +340,29 @@ def test_curse_sets_must_reveal_state_on_opponent():
     assert state.npc.must_reveal_played_card is True
 
 
+def test_karen_choose_activate_sets_must_reveal_on_opponent():
+    karen = Card(
+        "c45",
+        "可憐",
+        "かれん",
+        Janken.ROCK,
+        10,
+        Effect(EffectType.CHOOSE, "choose", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.ROCK, 9, None)
+    state = GameState(
+        player=PlayerState(hand=[karen]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, karen, other)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+
+    state = resume_round_effect(state, choice="activate")
+
+    assert state.npc.must_reveal_played_card is True
+
+
 def test_ami_restart_does_not_duplicate_played_cards():
     ami = Card(
         "c11",

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -360,7 +360,8 @@ def test_karen_choose_activate_sets_must_reveal_on_opponent():
 
     state = resume_round_effect(state, choice="activate")
 
-    assert state.npc.must_reveal_played_card is True
+    assert state.npc.must_reveal_played_card is False
+    assert state.npc.must_reveal_played_card_rounds == 2
 
 
 def test_ami_restart_does_not_duplicate_played_cards():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -289,6 +289,24 @@ def test_resolve_round_consumes_must_reveal_played_card_and_records_reveal(mock_
     assert next_state.revealed_this_round_side == Side.NPC
 
 
+def test_resolve_round_consumes_must_reveal_played_card_rounds(mock_cards):
+    p1, n1, p2, n2 = mock_cards
+    state = GameState(
+        player=PlayerState(hand=[p1, p2]),
+        npc=PlayerState(hand=[n1, n2], must_reveal_played_card_rounds=2),
+        phase=Phase.SELECT,
+    )
+
+    round_1 = resolve_round(state, p1, n1)
+    assert round_1.revealed_this_round == [n1]
+    assert round_1.npc.must_reveal_played_card_rounds == 1
+
+    round_2_start = proceed_to_next(round_1)
+    round_2 = resolve_round(round_2_start, p2, n2)
+    assert round_2.revealed_this_round == [n2]
+    assert round_2.npc.must_reveal_played_card_rounds == 0
+
+
 def test_proceed_to_next_resolves_remaining_forfeit_rounds(mock_cards):
     forfeited_1, npc_card, forfeited_2, forfeited_3 = mock_cards
     state = GameState(


### PR DESCRIPTION
## 概要
- `choose` 効果の分岐を `PendingEffectContext.card_id` / `payload.choose_variant` ベースで整理
- 百合子（card_26/c26）と可憐（card_45/c45）の選択肢・遷移・ログを分離
  - 百合子: `gain_points` / `draw_cards`（2段階目は手札IDのカンマ区切り）
  - 可憐: `activate` / `skip`
- UI (`app.py`) と NPC 選択 (`engine.py`) もカード別仕様に追従し、誤選択を防止
- 既存テストを新しい `choice` 仕様に合わせて更新

## テスト
- `ruff format app.py shadow_bout/effect_handlers.py shadow_bout/engine.py tests/test_effects.py`
- `ruff check --fix --extend-select I .`
- `.venv/bin/python -m pytest`
