### PR TITLE
feat(effects): implement steal_draw effect for serika

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -320,6 +320,41 @@ def effect_draw(state: GameState, side: Side, card: Card) -> GameState:
     )
 
 
+@register("steal_draw")
+def effect_steal_draw(state: GameState, side: Side, card: Card) -> GameState:
+    opp_side = get_opponent_side(side)
+    opp_state = get_player_state(state, opp_side)
+
+    if not opp_state.deck:
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手の山札が空のため不発"],
+        )
+
+    stolen = opp_state.deck[0]
+    state = update_player(
+        state,
+        opp_side,
+        deck=opp_state.deck[1:],
+    )
+
+    own_state = get_player_state(state, side)
+    state = update_player(
+        state,
+        side,
+        hand=own_state.hand + [stolen],
+    )
+
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [
+            f"{card.name}の効果発動: 相手の山札の上から{stolen.name}を奪って手札に加えた"
+        ],
+    )
+
+
 @register("buff_dynamic")
 def effect_buff_dynamic(state: GameState, side: Side, card: Card) -> GameState:
     p_state = get_player_state(state, side)

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -527,6 +527,50 @@ def test_takane_draw_reveals_both_remaining_hands_persistently():
     assert next_state.npc.revealed_card_ids == frozenset({n_extra.id})
 
 
+def test_steal_draw_effect_moves_top_card_from_opponent_deck_to_own_hand():
+    serika = Card(
+        "card_22",
+        "星梨花",
+        "せりか",
+        Janken.ROCK,
+        13,
+        Effect(EffectType.STEAL_DRAW, "steal draw", 1),
+    )
+    other = Card("cx", "other", "おざー", Janken.ROCK, 13, None)
+    stolen = Card("n1", "n1", "えぬ1", Janken.PAPER, 1)
+    remain = Card("n2", "n2", "えぬ2", Janken.SCISSORS, 2)
+    state = GameState(
+        player=PlayerState(hand=[serika]),
+        npc=PlayerState(hand=[other], deck=[stolen, remain]),
+    )
+
+    state = resolve_round(state, serika, other)
+
+    assert state.player.hand == [stolen]
+    assert state.npc.deck == [remain]
+
+
+def test_steal_draw_effect_noops_when_opponent_deck_is_empty():
+    serika = Card(
+        "card_22",
+        "星梨花",
+        "せりか",
+        Janken.ROCK,
+        13,
+        Effect(EffectType.STEAL_DRAW, "steal draw", 1),
+    )
+    other = Card("cx", "other", "おざー", Janken.ROCK, 13, None)
+    state = GameState(
+        player=PlayerState(hand=[serika]),
+        npc=PlayerState(hand=[other], deck=[]),
+    )
+
+    state = resolve_round(state, serika, other)
+
+    assert state.player.hand == []
+    assert state.npc.deck == []
+
+
 def test_draw_effect_draws_two_cards_for_both_sides():
     emily = Card(
         "card_20",


### PR DESCRIPTION
## 概要
- `steal_draw` 効果を実装し、相手山札の先頭1枚を自分の手札へ移動する処理を追加
- 相手山札が空のときは不発として安全に終了し、ログを追加
- 通常ケースと不発ケースのテストを追加

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
