### PR TITLE
feat(effects): add debuff handler for yukiho and kotoha

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -14,6 +14,7 @@ from shadow_bout.effect_utils import (
 from shadow_bout.models import (
     Card,
     GameState,
+    Janken,
     PendingEffectContext,
     PersistentPointEffect,
     Phase,
@@ -347,6 +348,47 @@ def effect_buff_next(state: GameState, side: Side, card: Card) -> GameState:
         battle_log=state.battle_log
         + [f"{card.name}の効果発動: 次ラウンドのポイント{bonus:+d}"],
     )
+
+
+@register("debuff")
+def effect_debuff(state: GameState, side: Side, card: Card) -> GameState:
+    opp_side = get_opponent_side(side)
+    opp_state = get_player_state(state, opp_side)
+
+    if card.id in ("card_04", "c4"):
+        current_battle = state.current_battle
+        opp_card = (
+            current_battle.npc_card
+            if opp_side == Side.NPC
+            else current_battle.player_card
+        )
+        conditional = (
+            opp_state.conditional_point_modifier_non_wildcard
+            if opp_card.janken != Janken.WILDCARD
+            else 0
+        )
+        current_point = opp_card.base_point + opp_state.point_modifier + conditional
+        halved_point = current_point // 2
+        new_modifier = halved_point - opp_card.base_point - conditional
+        state = update_player(state, opp_side, point_modifier=new_modifier)
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手のポイントを半分(切り捨て)にした"],
+        )
+
+    if card.id in ("card_17", "c17"):
+        debuff = len(opp_state.hand) * int(card.effect.value or 0)
+        state = update_player(
+            state, opp_side, point_modifier=opp_state.point_modifier + debuff
+        )
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手の手札枚数ぶんポイント{debuff:+d}"],
+        )
+
+    return state
 
 
 @register("conditional_debuff_next")

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -698,6 +698,57 @@ def test_conditional_debuff_next_does_not_apply_to_wildcard():
     assert calculate_effective_point(wildcard, next_state.player) == wildcard.base_point
 
 
+def test_debuff_yukiho_halves_opponent_point_floor_for_even_and_odd():
+    yukiho = Card(
+        "card_04",
+        "雪歩",
+        "ゆきほ",
+        Janken.PAPER,
+        11,
+        Effect(EffectType.DEBUFF, "halve opponent point", 0.5),
+    )
+    odd_point_card = Card("p_odd", "p_odd", "ぴーodd", Janken.PAPER, 11, None)
+    even_point_card = Card("p_even", "p_even", "ぴーeven", Janken.PAPER, 12, None)
+    n_other = Card("n2", "n2", "えぬ2", Janken.PAPER, 1, None)
+
+    odd_state = GameState(
+        player=PlayerState(hand=[odd_point_card]),
+        npc=PlayerState(hand=[yukiho, n_other]),
+    )
+    odd_state = resolve_round(odd_state, odd_point_card, yukiho)
+    assert odd_state.current_battle.player_point == 5
+
+    even_state = GameState(
+        player=PlayerState(hand=[even_point_card]),
+        npc=PlayerState(hand=[yukiho, n_other]),
+    )
+    even_state = resolve_round(even_state, even_point_card, yukiho)
+    assert even_state.current_battle.player_point == 6
+
+
+def test_debuff_kotoha_reduces_by_opponent_hand_count():
+    kotoha = Card(
+        "card_17",
+        "琴葉",
+        "ことは",
+        Janken.SCISSORS,
+        14,
+        Effect(EffectType.DEBUFF, "opponent hand count x -1", -1),
+    )
+    p_card = Card("p1", "p1", "ぴー1", Janken.SCISSORS, 15, None)
+    p_extra_1 = Card("p2", "p2", "ぴー2", Janken.ROCK, 1, None)
+    p_extra_2 = Card("p3", "p3", "ぴー3", Janken.PAPER, 1, None)
+    n_other = Card("n2", "n2", "えぬ2", Janken.SCISSORS, 1, None)
+    state = GameState(
+        player=PlayerState(hand=[p_card, p_extra_1, p_extra_2]),
+        npc=PlayerState(hand=[kotoha, n_other]),
+    )
+
+    state = resolve_round(state, p_card, kotoha)
+
+    assert state.current_battle.player_point == 13
+
+
 def test_debuff_persistent_applies_current_and_next_round_only():
     hinata = Card(
         "c35",


### PR DESCRIPTION
## 概要
- `debuff` typeの効果ハンドラを追加し、card_04（雪歩）とcard_17（琴葉）の挙動をカードIDで分岐実装
- 雪歩は相手の現在ポイントを半減（切り捨て）するように実装
- 琴葉は相手手札枚数に応じて減点するように実装
- 対応テストを追加（雪歩: 偶数/奇数ポイント、琴葉: 手札枚数依存）

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
