### PR TITLE
feat(effects): implement steal_hand effect

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -355,6 +355,40 @@ def effect_steal_draw(state: GameState, side: Side, card: Card) -> GameState:
     )
 
 
+@register("steal_hand")
+def effect_steal_hand(state: GameState, side: Side, card: Card) -> GameState:
+    opp_side = get_opponent_side(side)
+    opp_state = get_player_state(state, opp_side)
+
+    if not opp_state.hand:
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手の手札が空のため不発"],
+        )
+
+    stolen_idx = random.randrange(len(opp_state.hand))
+    stolen = opp_state.hand[stolen_idx]
+    state = update_player(
+        state,
+        opp_side,
+        hand=[c for i, c in enumerate(opp_state.hand) if i != stolen_idx],
+    )
+
+    own_state = get_player_state(state, side)
+    state = update_player(
+        state,
+        side,
+        hand=own_state.hand + [stolen],
+    )
+
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手の手札から{stolen.name}を奪って手札に加えた"],
+    )
+
+
 @register("buff_dynamic")
 def effect_buff_dynamic(state: GameState, side: Side, card: Card) -> GameState:
     p_state = get_player_state(state, side)

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,3 +1,5 @@
+import random
+
 from shadow_bout.effects import calculate_effective_point
 from shadow_bout.engine import (
     continue_round_effect_step,
@@ -569,6 +571,51 @@ def test_steal_draw_effect_noops_when_opponent_deck_is_empty():
 
     assert state.player.hand == []
     assert state.npc.deck == []
+
+
+def test_steal_hand_effect_moves_random_card_from_opponent_hand_to_own_hand():
+    random.seed(0)
+    rio = Card(
+        "card_46",
+        "莉緒",
+        "りお",
+        Janken.SCISSORS,
+        11,
+        Effect(EffectType.STEAL_HAND, "steal hand", 1),
+    )
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 11, None)
+    n1 = Card("n1", "n1", "えぬ1", Janken.PAPER, 1)
+    n2 = Card("n2", "n2", "えぬ2", Janken.ROCK, 2)
+    state = GameState(
+        player=PlayerState(hand=[rio]),
+        npc=PlayerState(hand=[other, n1, n2]),
+    )
+
+    state = resolve_round(state, rio, other)
+
+    assert state.player.hand == [n2]
+    assert state.npc.hand == [n1]
+
+
+def test_steal_hand_effect_noops_when_opponent_hand_is_empty():
+    rio = Card(
+        "card_46",
+        "莉緒",
+        "りお",
+        Janken.SCISSORS,
+        11,
+        Effect(EffectType.STEAL_HAND, "steal hand", 1),
+    )
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 11, None)
+    state = GameState(
+        player=PlayerState(hand=[rio]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, rio, other)
+
+    assert state.player.hand == []
+    assert state.npc.hand == []
 
 
 def test_draw_effect_draws_two_cards_for_both_sides():


### PR DESCRIPTION
## 概要
- `steal_hand` type（card_46: 莉緒）を実装。
- 相手手札からランダム1枚を奪って自分手札へ加える処理を追加。
- 相手手札が0枚の場合は不発となるログを追加。
- 正常系（`random.seed(0)` 固定）と不発系のテストを追加。

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
