### PR TITLE
feat(effects): add set_point handler for azusa

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -426,6 +426,30 @@ def effect_debuff(state: GameState, side: Side, card: Card) -> GameState:
     return state
 
 
+@register("set_point")
+def effect_set_point(state: GameState, side: Side, card: Card) -> GameState:
+    opp_side = get_opponent_side(side)
+    opp_state = get_player_state(state, opp_side)
+
+    set_value = int(card.effect.value or 0)
+    current_battle = state.current_battle
+    opp_card = (
+        current_battle.npc_card if opp_side == Side.NPC else current_battle.player_card
+    )
+    conditional = (
+        opp_state.conditional_point_modifier_non_wildcard
+        if opp_card.janken != Janken.WILDCARD
+        else 0
+    )
+    new_modifier = set_value - opp_card.base_point - conditional
+    state = update_player(state, opp_side, point_modifier=new_modifier)
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手のポイントを{set_value}にした"],
+    )
+
+
 @register("conditional_debuff_next")
 def effect_conditional_debuff_next(
     state: GameState, side: Side, card: Card

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -793,6 +793,58 @@ def test_debuff_kotoha_reduces_by_opponent_hand_count():
     assert state.current_battle.player_point == 13
 
 
+def test_set_point_azusa_sets_opponent_point_to_zero():
+    azusa = Card(
+        "card_10",
+        "あずさ",
+        "あずさ",
+        Janken.SCISSORS,
+        10,
+        Effect(EffectType.SET_POINT, "set point", 0),
+    )
+    other = Card("op", "other", "おざー", Janken.SCISSORS, 18, None)
+    state = GameState(
+        player=PlayerState(hand=[azusa]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, azusa, other)
+
+    assert state.current_battle.player_point == 10
+    assert state.current_battle.npc_point == 0
+    assert state.current_battle.outcome == RoundOutcome.WIN
+
+
+def test_set_point_works_consistently_with_existing_point_modifier_order():
+    azusa = Card(
+        "card_10",
+        "あずさ",
+        "あずさ",
+        Janken.SCISSORS,
+        10,
+        Effect(EffectType.SET_POINT, "set point", 0),
+    )
+    takane = Card(
+        "c8",
+        "貴音",
+        "たかね",
+        Janken.SCISSORS,
+        14,
+        Effect(EffectType.BUFF, "+1", 1),
+    )
+    state = GameState(
+        player=PlayerState(hand=[azusa]),
+        npc=PlayerState(hand=[takane]),
+    )
+
+    state = resolve_round(state, azusa, takane)
+
+    assert state.current_battle.player_point == 10
+    # あずさ(10)→貴音(14)の順で効果解決されるため、0固定の後に+1される
+    assert state.current_battle.npc_point == 1
+    assert state.current_battle.outcome == RoundOutcome.WIN
+
+
 def test_debuff_persistent_applies_current_and_next_round_only():
     hinata = Card(
         "c35",


### PR DESCRIPTION
## 概要
- `set_point` 効果ハンドラを追加し、相手のこの勝負の有効ポイントを指定値に固定できるようにしました（card_10 あずさ想定）。
- `tests/test_effects.py` に単独適用ケースと、既存ポイント補正（貴音の+1）との併用ケースを追加しました。

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
