### PR TITLE
feat(effects): add conditional_buff handler for noriko

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -450,6 +450,39 @@ def effect_set_point(state: GameState, side: Side, card: Card) -> GameState:
     )
 
 
+@register("conditional_buff")
+def effect_conditional_buff(state: GameState, side: Side, card: Card) -> GameState:
+    p_state = get_player_state(state, side)
+    opp_side = get_opponent_side(side)
+    opp_state = get_player_state(state, opp_side)
+
+    own_won_total = sum(won.base_point for won in p_state.won_cards)
+    opp_won_total = sum(won.base_point for won in opp_state.won_cards)
+    bonus = int(card.effect.value or 0)
+
+    if opp_won_total > own_won_total:
+        state = update_player(
+            state,
+            side,
+            point_modifier=p_state.point_modifier + bonus,
+        )
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [
+                f"{card.name}の効果発動: 相手の勝ち札合計({opp_won_total}) > 自分({own_won_total})のためポイント+{bonus}"
+            ],
+        )
+
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [
+            f"{card.name}の効果発動: 相手の勝ち札合計({opp_won_total}) <= 自分({own_won_total})のため不発"
+        ],
+    )
+
+
 @register("conditional_debuff_next")
 def effect_conditional_debuff_next(
     state: GameState, side: Side, card: Card

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -981,3 +981,53 @@ def test_ban_clears_forced_card_id_when_target_is_forced_card():
 
     assert state.npc.banned_card_ids == frozenset({forced.id})
     assert state.npc.forced_card_id is None
+
+
+def test_conditional_buff_applies_when_opponent_won_total_is_higher():
+    noriko = Card(
+        "card_43",
+        "のり子",
+        "のりこ",
+        Janken.PAPER,
+        14,
+        Effect(EffectType.CONDITIONAL_BUFF, "conditional buff", 7),
+    )
+    other = Card("cx", "other", "おざー", Janken.PAPER, 14, None)
+    own_won = Card("w1", "own", "おうん", Janken.ROCK, 10)
+    opp_won = Card("w2", "opp", "おっぷ", Janken.ROCK, 16)
+    state = GameState(
+        player=PlayerState(hand=[noriko], won_cards=[own_won]),
+        npc=PlayerState(hand=[other], won_cards=[opp_won]),
+    )
+
+    state = resolve_round(state, noriko, other)
+
+    assert state.phase == Phase.REVEAL
+    assert state.current_battle.player_point == 21
+    assert state.current_battle.npc_point == 14
+    assert any("ポイント+7" in log for log in state.battle_log)
+
+
+def test_conditional_buff_does_not_apply_when_opponent_won_total_is_not_higher():
+    noriko = Card(
+        "card_43",
+        "のり子",
+        "のりこ",
+        Janken.PAPER,
+        14,
+        Effect(EffectType.CONDITIONAL_BUFF, "conditional buff", 7),
+    )
+    other = Card("cx", "other", "おざー", Janken.PAPER, 14, None)
+    own_won = Card("w1", "own", "おうん", Janken.ROCK, 16)
+    opp_won = Card("w2", "opp", "おっぷ", Janken.ROCK, 10)
+    state = GameState(
+        player=PlayerState(hand=[noriko], won_cards=[own_won]),
+        npc=PlayerState(hand=[other], won_cards=[opp_won]),
+    )
+
+    state = resolve_round(state, noriko, other)
+
+    assert state.phase == Phase.REVEAL
+    assert state.current_battle.player_point == 14
+    assert state.current_battle.npc_point == 14
+    assert any("不発" in log for log in state.battle_log)


### PR DESCRIPTION
## 概要
- `conditional_buff` タイプの効果処理を追加し、相手の勝ち札合計が自分より高いときのみポイント加算するように実装
- 条件成立/不成立をバトルログに記録
- 成立ケース・不成立ケースのテストを追加

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
