### PR TITLE
feat(effects): implement draw_dynamic for card_19

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -321,6 +321,36 @@ def effect_draw(state: GameState, side: Side, card: Card) -> GameState:
     )
 
 
+@register("draw_dynamic")
+def effect_draw_dynamic(state: GameState, side: Side, card: Card) -> GameState:
+    own_state = get_player_state(state, side)
+    moved_count = len(own_state.discard)
+
+    if moved_count == 0:
+        return replace(
+            state,
+            battle_log=state.battle_log + [f"{card.name}の効果発動: 捨札がなく不発"],
+        )
+
+    new_deck = own_state.deck + own_state.discard
+    random.shuffle(new_deck)
+    drawn = new_deck[:moved_count]
+    state = update_player(
+        state,
+        side,
+        hand=own_state.hand + drawn,
+        deck=new_deck[len(drawn) :],
+        discard=[],
+    )
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [
+            f"{card.name}の効果発動: 捨札{moved_count}枚を山札に戻して{len(drawn)}枚ドロー"
+        ],
+    )
+
+
 @register("steal_draw")
 def effect_steal_draw(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -701,6 +701,85 @@ def test_draw_effect_for_haruka_returns_hands_to_deck_then_draws():
     assert len(state.npc.deck) == 0
 
 
+def test_draw_dynamic_effect_shuffles_discards_into_deck_and_draws_same_count():
+    random.seed(0)
+    minako = Card(
+        "card_19",
+        "美奈子",
+        "みなこ",
+        Janken.SCISSORS,
+        11,
+        Effect(EffectType.DRAW_DYNAMIC, "draw dynamic", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 11, None)
+    p_deck_1 = Card("p_d1", "p_d1", "ぴd1", Janken.ROCK, 3)
+    p_discard_1 = Card("p_x1", "p_x1", "ぴx1", Janken.PAPER, 1)
+    p_discard_2 = Card("p_x2", "p_x2", "ぴx2", Janken.SCISSORS, 2)
+    state = GameState(
+        player=PlayerState(
+            hand=[minako], deck=[p_deck_1], discard=[p_discard_1, p_discard_2]
+        ),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, minako, other)
+
+    assert len(state.player.hand) == 2
+    assert len(state.player.deck) == 1
+    assert state.player.discard == []
+
+
+def test_draw_dynamic_effect_noops_when_discard_is_empty():
+    minako = Card(
+        "card_19",
+        "美奈子",
+        "みなこ",
+        Janken.SCISSORS,
+        11,
+        Effect(EffectType.DRAW_DYNAMIC, "draw dynamic", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 11, None)
+    p_deck_1 = Card("p_d1", "p_d1", "ぴd1", Janken.ROCK, 3)
+    state = GameState(
+        player=PlayerState(hand=[minako], deck=[p_deck_1], discard=[]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, minako, other)
+
+    assert state.player.hand == []
+    assert state.player.deck == [p_deck_1]
+    assert state.player.discard == []
+
+
+def test_draw_dynamic_effect_draws_only_available_cards_when_deck_short():
+    random.seed(0)
+    minako = Card(
+        "card_19",
+        "美奈子",
+        "みなこ",
+        Janken.SCISSORS,
+        11,
+        Effect(EffectType.DRAW_DYNAMIC, "draw dynamic", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 11, None)
+    p_discard_1 = Card("p_x1", "p_x1", "ぴx1", Janken.PAPER, 1)
+    p_discard_2 = Card("p_x2", "p_x2", "ぴx2", Janken.SCISSORS, 2)
+    p_discard_3 = Card("p_x3", "p_x3", "ぴx3", Janken.ROCK, 3)
+    state = GameState(
+        player=PlayerState(
+            hand=[minako], deck=[], discard=[p_discard_1, p_discard_2, p_discard_3]
+        ),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, minako, other)
+
+    assert len(state.player.hand) == 3
+    assert state.player.deck == []
+    assert state.player.discard == []
+
+
 def test_buff_next_is_applied_only_on_next_round_for_player_side():
     iori = Card(
         "c7",


### PR DESCRIPTION
## 概要
- `draw_dynamic` 効果を実装し、捨札を山札に戻してシャッフル後、戻した枚数ぶんドローする処理を追加
- 捨札0枚時の不発処理と、山札不足時に引ける分だけ引く挙動を追加
- 正常系 / 捨札0枚 / 山札不足ケースのテストを追加

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
