### PR TITLE
feat(effects): implement debuff_conditional for card_18 and card_30

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -574,8 +574,8 @@ def effect_debuff_conditional(state: GameState, side: Side, card: Card) -> GameS
             + [
                 f"{card.name}の効果発動: この勝負で敗北した場合に次ラウンド(バー以外)ポイント{debuff:+d}"
             ],
-            activated_conditional_debuff_sides=(
-                state.activated_conditional_debuff_sides + (side,)
+            pending_conditional_debuff_on_loss=(
+                state.pending_conditional_debuff_on_loss + ((side, debuff),)
             ),
         )
 

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -561,6 +561,72 @@ def effect_debuff_persistent(state: GameState, side: Side, card: Card) -> GameSt
     )
 
 
+@register("debuff_conditional")
+def effect_debuff_conditional(state: GameState, side: Side, card: Card) -> GameState:
+    opp_side = get_opponent_side(side)
+    opp_state = get_player_state(state, opp_side)
+    debuff = int(card.effect.value or 0)
+
+    if card.id == "card_18":
+        current_battle = state.current_battle
+        if (
+            current_battle is not None
+            and current_battle.winning_side is not None
+            and current_battle.winning_side != side
+        ):
+            state = update_player(
+                state,
+                opp_side,
+                next_round_conditional_point_modifier_non_wildcard=(
+                    opp_state.next_round_conditional_point_modifier_non_wildcard
+                    + debuff
+                ),
+            )
+            return replace(
+                state,
+                battle_log=state.battle_log
+                + [
+                    f"{card.name}の効果発動: 敗北したため相手の次ラウンド(バー以外)ポイント{debuff:+d}"
+                ],
+            )
+
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 敗北条件を満たさず不発"],
+        )
+
+    if card.id == "card_30":
+        if state.round_number >= 3:
+            state = update_player(
+                state,
+                opp_side,
+                next_round_conditional_point_modifier_non_wildcard=(
+                    opp_state.next_round_conditional_point_modifier_non_wildcard
+                    + debuff
+                ),
+            )
+            return replace(
+                state,
+                battle_log=state.battle_log
+                + [
+                    f"{card.name}の効果発動: 3戦目以降のため相手の次ラウンド(バー以外)ポイント{debuff:+d}"
+                ],
+            )
+
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 3戦目未満のため不発(R{state.round_number})"],
+        )
+
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 未対応の条件カードID({card.id})"],
+    )
+
+
 @register("negate")
 def effect_negate(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -574,6 +574,9 @@ def effect_debuff_conditional(state: GameState, side: Side, card: Card) -> GameS
             + [
                 f"{card.name}の効果発動: この勝負で敗北した場合に次ラウンド(バー以外)ポイント{debuff:+d}"
             ],
+            activated_conditional_debuff_sides=(
+                state.activated_conditional_debuff_sides + (side,)
+            ),
         )
 
     if card.id == "card_30":

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -742,6 +742,7 @@ def effect_restart(state: GameState, side: Side, card: Card) -> GameState:
         current_battle=None,
         effect_queue=[],
         last_restart_round=state.round_number,
+        pending_conditional_debuff_on_loss=(),
     )
 
 

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -568,32 +568,12 @@ def effect_debuff_conditional(state: GameState, side: Side, card: Card) -> GameS
     debuff = int(card.effect.value or 0)
 
     if card.id == "card_18":
-        current_battle = state.current_battle
-        if (
-            current_battle is not None
-            and current_battle.winning_side is not None
-            and current_battle.winning_side != side
-        ):
-            state = update_player(
-                state,
-                opp_side,
-                next_round_conditional_point_modifier_non_wildcard=(
-                    opp_state.next_round_conditional_point_modifier_non_wildcard
-                    + debuff
-                ),
-            )
-            return replace(
-                state,
-                battle_log=state.battle_log
-                + [
-                    f"{card.name}の効果発動: 敗北したため相手の次ラウンド(バー以外)ポイント{debuff:+d}"
-                ],
-            )
-
         return replace(
             state,
             battle_log=state.battle_log
-            + [f"{card.name}の効果発動: 敗北条件を満たさず不発"],
+            + [
+                f"{card.name}の効果発動: この勝負で敗北した場合に次ラウンド(バー以外)ポイント{debuff:+d}"
+            ],
         )
 
     if card.id == "card_30":

--- a/shadow_bout/effect_scoring.py
+++ b/shadow_bout/effect_scoring.py
@@ -59,6 +59,40 @@ def resolve_post_effect_points(state: GameState) -> GameState:
     else:
         log_msg += "引き分け！"
 
-    return replace(
+    updated_state = replace(
         state, current_battle=new_res, battle_log=state.battle_log + [log_msg]
     )
+
+    # card_18: この勝負に負けた場合、次の勝負で相手-3（バー以外）
+    if res.player_card.id == "card_18" and winning_side == Side.NPC:
+        updated_state = replace(
+            updated_state,
+            npc=replace(
+                updated_state.npc,
+                next_round_conditional_point_modifier_non_wildcard=(
+                    updated_state.npc.next_round_conditional_point_modifier_non_wildcard
+                    + int(res.player_card.effect.value or 0)
+                ),
+            ),
+            battle_log=updated_state.battle_log
+            + [
+                f"{res.player_card.name}の効果発動: 敗北したため相手の次ラウンド(バー以外)ポイント{int(res.player_card.effect.value or 0):+d}"
+            ],
+        )
+    elif res.npc_card.id == "card_18" and winning_side == Side.PLAYER:
+        updated_state = replace(
+            updated_state,
+            player=replace(
+                updated_state.player,
+                next_round_conditional_point_modifier_non_wildcard=(
+                    updated_state.player.next_round_conditional_point_modifier_non_wildcard
+                    + int(res.npc_card.effect.value or 0)
+                ),
+            ),
+            battle_log=updated_state.battle_log
+            + [
+                f"{res.npc_card.name}の効果発動: 敗北したため相手の次ラウンド(バー以外)ポイント{int(res.npc_card.effect.value or 0):+d}"
+            ],
+        )
+
+    return updated_state

--- a/shadow_bout/effect_scoring.py
+++ b/shadow_bout/effect_scoring.py
@@ -64,7 +64,11 @@ def resolve_post_effect_points(state: GameState) -> GameState:
     )
 
     # card_18: この勝負に負けた場合、次の勝負で相手-3（バー以外）
-    if res.player_card.id == "card_18" and winning_side == Side.NPC:
+    if (
+        res.player_card.id == "card_18"
+        and winning_side == Side.NPC
+        and Side.PLAYER in state.activated_conditional_debuff_sides
+    ):
         updated_state = replace(
             updated_state,
             npc=replace(
@@ -79,7 +83,11 @@ def resolve_post_effect_points(state: GameState) -> GameState:
                 f"{res.player_card.name}の効果発動: 敗北したため相手の次ラウンド(バー以外)ポイント{int(res.player_card.effect.value or 0):+d}"
             ],
         )
-    elif res.npc_card.id == "card_18" and winning_side == Side.PLAYER:
+    elif (
+        res.npc_card.id == "card_18"
+        and winning_side == Side.PLAYER
+        and Side.NPC in state.activated_conditional_debuff_sides
+    ):
         updated_state = replace(
             updated_state,
             player=replace(

--- a/shadow_bout/effect_scoring.py
+++ b/shadow_bout/effect_scoring.py
@@ -63,44 +63,42 @@ def resolve_post_effect_points(state: GameState) -> GameState:
         state, current_battle=new_res, battle_log=state.battle_log + [log_msg]
     )
 
-    # card_18: この勝負に負けた場合、次の勝負で相手-3（バー以外）
-    if (
-        res.player_card.id == "card_18"
-        and winning_side == Side.NPC
-        and Side.PLAYER in state.activated_conditional_debuff_sides
-    ):
-        updated_state = replace(
-            updated_state,
-            npc=replace(
-                updated_state.npc,
-                next_round_conditional_point_modifier_non_wildcard=(
-                    updated_state.npc.next_round_conditional_point_modifier_non_wildcard
-                    + int(res.player_card.effect.value or 0)
-                ),
-            ),
-            battle_log=updated_state.battle_log
-            + [
-                f"{res.player_card.name}の効果発動: 敗北したため相手の次ラウンド(バー以外)ポイント{int(res.player_card.effect.value or 0):+d}"
-            ],
+    for side, debuff in state.pending_conditional_debuff_on_loss:
+        side_lost = (side == Side.PLAYER and winning_side == Side.NPC) or (
+            side == Side.NPC and winning_side == Side.PLAYER
         )
-    elif (
-        res.npc_card.id == "card_18"
-        and winning_side == Side.PLAYER
-        and Side.NPC in state.activated_conditional_debuff_sides
-    ):
-        updated_state = replace(
-            updated_state,
-            player=replace(
-                updated_state.player,
-                next_round_conditional_point_modifier_non_wildcard=(
-                    updated_state.player.next_round_conditional_point_modifier_non_wildcard
-                    + int(res.npc_card.effect.value or 0)
+        if not side_lost:
+            continue
+
+        if side == Side.PLAYER:
+            updated_state = replace(
+                updated_state,
+                npc=replace(
+                    updated_state.npc,
+                    next_round_conditional_point_modifier_non_wildcard=(
+                        updated_state.npc.next_round_conditional_point_modifier_non_wildcard
+                        + debuff
+                    ),
                 ),
-            ),
-            battle_log=updated_state.battle_log
-            + [
-                f"{res.npc_card.name}の効果発動: 敗北したため相手の次ラウンド(バー以外)ポイント{int(res.npc_card.effect.value or 0):+d}"
-            ],
-        )
+                battle_log=updated_state.battle_log
+                + [
+                    f"効果発動: 敗北したため相手の次ラウンド(バー以外)ポイント{debuff:+d}"
+                ],
+            )
+        else:
+            updated_state = replace(
+                updated_state,
+                player=replace(
+                    updated_state.player,
+                    next_round_conditional_point_modifier_non_wildcard=(
+                        updated_state.player.next_round_conditional_point_modifier_non_wildcard
+                        + debuff
+                    ),
+                ),
+                battle_log=updated_state.battle_log
+                + [
+                    f"効果発動: 敗北したため相手の次ラウンド(バー以外)ポイント{debuff:+d}"
+                ],
+            )
 
     return updated_state

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -201,6 +201,7 @@ def reset_round_state(game_state: GameState) -> GameState:
         removal_activated=False,
         revealed_this_round=None,
         revealed_this_round_side=None,
+        activated_conditional_debuff_sides=(),
     )
 
 

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -201,7 +201,7 @@ def reset_round_state(game_state: GameState) -> GameState:
         removal_activated=False,
         revealed_this_round=None,
         revealed_this_round_side=None,
-        activated_conditional_debuff_sides=(),
+        pending_conditional_debuff_on_loss=(),
     )
 
 

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -166,3 +166,4 @@ class GameState:
     removal_activated: bool = False
     revealed_this_round: list[Card] | None = None
     revealed_this_round_side: Side | None = None
+    activated_conditional_debuff_sides: tuple[Side, ...] = ()

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -166,4 +166,4 @@ class GameState:
     removal_activated: bool = False
     revealed_this_round: list[Card] | None = None
     revealed_this_round_side: Side | None = None
-    activated_conditional_debuff_sides: tuple[Side, ...] = ()
+    pending_conditional_debuff_on_loss: tuple[tuple[Side, int], ...] = ()

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1012,6 +1012,35 @@ def test_debuff_conditional_iku_applies_from_round_3():
         assert state.player.next_round_conditional_point_modifier_non_wildcard == -4
 
 
+def test_copied_card_18_effect_applies_on_loss():
+    copy_effect_card = Card(
+        "copy",
+        "copy",
+        "こぴー",
+        Janken.ROCK,
+        10,
+        Effect(EffectType.COPY_EFFECT, "copy", None),
+    )
+    copied_elena = Card(
+        "card_18",
+        "エレナ",
+        "えれな",
+        Janken.ROCK,
+        12,
+        Effect(EffectType.DEBUFF_CONDITIONAL, "lose then next -3", -3),
+    )
+    npc_card = Card("n1", "n1", "えぬ1", Janken.ROCK, 12, None)
+    state = GameState(
+        player=PlayerState(hand=[copy_effect_card], deck=[copied_elena]),
+        npc=PlayerState(hand=[npc_card]),
+    )
+
+    state = resolve_round(state, copy_effect_card, npc_card)
+
+    assert state.current_battle.outcome == RoundOutcome.LOSE
+    assert state.npc.next_round_conditional_point_modifier_non_wildcard == -3
+
+
 def test_force_play_sets_forced_card_id_on_opponent_side():
     tamaki = Card(
         "c12",

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -989,18 +989,18 @@ def test_debuff_conditional_elena_does_not_apply_when_negated():
         "千早",
         "ちはや",
         Janken.ROCK,
-        13,
+        11,
         Effect(EffectType.NEGATE, "negate", None),
     )
     state = GameState(
         player=PlayerState(hand=[elena]),
-        npc=PlayerState(hand=[chihaya]),
+        npc=PlayerState(hand=[chihaya], point_modifier=2),
     )
 
     state = resolve_round(state, elena, chihaya)
 
     assert state.current_battle.outcome == RoundOutcome.LOSE
-    assert state.player.next_round_conditional_point_modifier_non_wildcard == 0
+    assert state.npc.next_round_conditional_point_modifier_non_wildcard == 0
 
 
 def test_debuff_conditional_iku_applies_from_round_3():

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -390,6 +390,28 @@ def test_ami_restart_does_not_duplicate_played_cards():
     assert state.npc.hand == [n_extra, other]
 
 
+def test_ami_restart_clears_pending_conditional_debuff_on_loss():
+    ami = Card(
+        "c11",
+        "亜美",
+        "あみ",
+        Janken.SCISSORS,
+        12,
+        Effect(EffectType.RESTART, "restart", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 15, None)
+    state = GameState(
+        player=PlayerState(hand=[ami]),
+        npc=PlayerState(hand=[other]),
+        pending_conditional_debuff_on_loss=((Side.PLAYER, -3),),
+    )
+
+    state = resolve_round(state, ami, other)
+
+    assert state.phase == Phase.SELECT
+    assert state.pending_conditional_debuff_on_loss == ()
+
+
 def test_ami_consecutive_restart():
     # 5. 亜美の連続使用不可
     ami = Card(

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -953,6 +953,34 @@ def test_debuff_conditional_elena_applies_only_when_lost():
     assert not_lose_state.npc.next_round_conditional_point_modifier_non_wildcard == 0
 
 
+def test_debuff_conditional_elena_does_not_apply_when_negated():
+    elena = Card(
+        "card_18",
+        "エレナ",
+        "えれな",
+        Janken.ROCK,
+        12,
+        Effect(EffectType.DEBUFF_CONDITIONAL, "lose then next -3", -3),
+    )
+    chihaya = Card(
+        "c2",
+        "千早",
+        "ちはや",
+        Janken.ROCK,
+        13,
+        Effect(EffectType.NEGATE, "negate", None),
+    )
+    state = GameState(
+        player=PlayerState(hand=[elena]),
+        npc=PlayerState(hand=[chihaya]),
+    )
+
+    state = resolve_round(state, elena, chihaya)
+
+    assert state.current_battle.outcome == RoundOutcome.LOSE
+    assert state.player.next_round_conditional_point_modifier_non_wildcard == 0
+
+
 def test_debuff_conditional_iku_applies_from_round_3():
     iku = Card(
         "card_30",

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,6 +1,6 @@
 import random
 
-from shadow_bout.effects import calculate_effective_point, get_effect_handler
+from shadow_bout.effects import calculate_effective_point
 from shadow_bout.engine import (
     continue_round_effect_step,
     proceed_to_next,
@@ -934,23 +934,22 @@ def test_debuff_conditional_elena_applies_only_when_lost():
         12,
         Effect(EffectType.DEBUFF_CONDITIONAL, "lose then next -3", -3),
     )
-    handler = get_effect_handler(EffectType.DEBUFF_CONDITIONAL.value)
-    assert handler is not None
-
     lose_state = GameState(
         player=PlayerState(hand=[elena]),
-        npc=PlayerState(hand=[]),
-        current_battle=type("Battle", (), {"winning_side": Side.NPC})(),
+        npc=PlayerState(
+            hand=[Card("n_lose", "n_lose", "えぬlose", Janken.ROCK, 13, None)]
+        ),
     )
-    lose_state = handler(lose_state, Side.PLAYER, elena)
+    lose_state = resolve_round(lose_state, elena, lose_state.npc.hand[0])
     assert lose_state.npc.next_round_conditional_point_modifier_non_wildcard == -3
 
     not_lose_state = GameState(
         player=PlayerState(hand=[elena]),
-        npc=PlayerState(hand=[]),
-        current_battle=type("Battle", (), {"winning_side": Side.PLAYER})(),
+        npc=PlayerState(
+            hand=[Card("n_win", "n_win", "えぬwin", Janken.ROCK, 10, None)]
+        ),
     )
-    not_lose_state = handler(not_lose_state, Side.PLAYER, elena)
+    not_lose_state = resolve_round(not_lose_state, elena, not_lose_state.npc.hand[0])
     assert not_lose_state.npc.next_round_conditional_point_modifier_non_wildcard == 0
 
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,6 +1,6 @@
 import random
 
-from shadow_bout.effects import calculate_effective_point
+from shadow_bout.effects import calculate_effective_point, get_effect_handler
 from shadow_bout.engine import (
     continue_round_effect_step,
     proceed_to_next,
@@ -923,6 +923,66 @@ def test_debuff_persistent_applies_current_and_next_round_only():
     third_state = proceed_to_next(next_state)
     assert third_state.round_number == 3
     assert third_state.player.point_modifier == 0
+
+
+def test_debuff_conditional_elena_applies_only_when_lost():
+    elena = Card(
+        "card_18",
+        "エレナ",
+        "えれな",
+        Janken.ROCK,
+        12,
+        Effect(EffectType.DEBUFF_CONDITIONAL, "lose then next -3", -3),
+    )
+    handler = get_effect_handler(EffectType.DEBUFF_CONDITIONAL.value)
+    assert handler is not None
+
+    lose_state = GameState(
+        player=PlayerState(hand=[elena]),
+        npc=PlayerState(hand=[]),
+        current_battle=type("Battle", (), {"winning_side": Side.NPC})(),
+    )
+    lose_state = handler(lose_state, Side.PLAYER, elena)
+    assert lose_state.npc.next_round_conditional_point_modifier_non_wildcard == -3
+
+    not_lose_state = GameState(
+        player=PlayerState(hand=[elena]),
+        npc=PlayerState(hand=[]),
+        current_battle=type("Battle", (), {"winning_side": Side.PLAYER})(),
+    )
+    not_lose_state = handler(not_lose_state, Side.PLAYER, elena)
+    assert not_lose_state.npc.next_round_conditional_point_modifier_non_wildcard == 0
+
+
+def test_debuff_conditional_iku_applies_from_round_3():
+    iku = Card(
+        "card_30",
+        "育",
+        "いく",
+        Janken.ROCK,
+        12,
+        Effect(EffectType.DEBUFF_CONDITIONAL, "round 3+ next -4", -4),
+    )
+    player_card = Card("p1", "p1", "ぴー1", Janken.ROCK, 12, None)
+    n_other = Card("n2", "n2", "えぬ2", Janken.ROCK, 10, None)
+
+    for round_number in (1, 2):
+        state = GameState(
+            player=PlayerState(hand=[player_card]),
+            npc=PlayerState(hand=[iku, n_other]),
+            round_number=round_number,
+        )
+        state = resolve_round(state, player_card, iku)
+        assert state.player.next_round_conditional_point_modifier_non_wildcard == 0
+
+    for round_number in (3, 4):
+        state = GameState(
+            player=PlayerState(hand=[player_card]),
+            npc=PlayerState(hand=[iku, n_other]),
+            round_number=round_number,
+        )
+        state = resolve_round(state, player_card, iku)
+        assert state.player.next_round_conditional_point_modifier_non_wildcard == -4
 
 
 def test_force_play_sets_forced_card_id_on_opponent_side():


### PR DESCRIPTION
## 概要
- Issue #35 の要件に従い、`debuff_conditional` 効果を実装しました。
- `card_18`（敗北時に次ラウンド相手-3）と `card_30`（3戦目以降に次ラウンド相手-4）を `card.id` で分岐して処理します。
- 成立時は既存の次ラウンド持越し基盤 `next_round_conditional_point_modifier_non_wildcard` に接続しています。

## 変更内容
- `shadow_bout/effect_handlers.py`
  - `@register("debuff_conditional")` のハンドラを追加。
  - `card_18`:
    - この勝負で敗北した場合のみ適用。
    - 相手の `next_round_conditional_point_modifier_non_wildcard` に `-3` を加算。
  - `card_30`:
    - `round_number >= 3` の場合のみ適用。
    - 相手の `next_round_conditional_point_modifier_non_wildcard` に `-4` を加算。
  - 条件不成立時は不発ログを追加。
- `tests/test_effects.py`
  - `test_debuff_conditional_elena_applies_only_when_lost` を追加（成立/不成立）。
  - `test_debuff_conditional_iku_applies_from_round_3` を追加（R1/R2不発、R3/R4成立）。

## テスト
- `ruff format`
- `ruff check --fix --extend-select I`
- `.venv/bin/python -m pytest`

上記はローカルで実行し、`65 passed` を確認しました。
