### PR TITLE
feat(effects): implement salvage interactive effect for card_41

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -202,7 +202,19 @@ def _resume_salvage(state: GameState, side: Side, choice: str | None) -> GameSta
     if target is None:
         return _finish_interactive_effect(state, "-> 風花の効果: 回収しない")
 
-    penalty = -3
+    ctx = state.pending_effect_context
+    source_card = None
+    if ctx is not None and state.current_battle is not None:
+        source_card = (
+            state.current_battle.player_card
+            if side == Side.PLAYER
+            else state.current_battle.npc_card
+        )
+        if source_card.id != ctx.card_id:
+            source_card = None
+    penalty = int(
+        source_card.effect.value if source_card and source_card.effect else -3
+    )
     new_discard = [card for card in p_state.discard if card.id != target.id]
     state = update_player(
         state,

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -52,6 +52,27 @@ def _find_card(cards: list[Card], card_id: str | None) -> Card | None:
     return next((card for card in cards if card.id == card_id), None)
 
 
+def _find_card_by_id(state: GameState, side: Side, card_id: str | None) -> Card | None:
+    p_state = get_player_state(state, side)
+    card_lists = [
+        p_state.hand,
+        p_state.deck,
+        p_state.discard,
+        p_state.won_cards,
+        p_state.draw_stock,
+    ]
+    if state.current_battle is not None:
+        card_lists.append(
+            [
+                state.current_battle.player_card,
+                state.current_battle.npc_card,
+            ]
+        )
+    return next(
+        (card for cards in card_lists for card in cards if card.id == card_id), None
+    )
+
+
 def _parse_card_ids(choice: str | None) -> list[str]:
     if not choice:
         return []
@@ -203,15 +224,7 @@ def _resume_salvage(state: GameState, side: Side, choice: str | None) -> GameSta
         return _finish_interactive_effect(state, "-> 風花の効果: 回収しない")
 
     ctx = state.pending_effect_context
-    source_card = None
-    if ctx is not None and state.current_battle is not None:
-        source_card = (
-            state.current_battle.player_card
-            if side == Side.PLAYER
-            else state.current_battle.npc_card
-        )
-        if source_card.id != ctx.card_id:
-            source_card = None
+    source_card = _find_card_by_id(state, side, ctx.card_id if ctx else None)
     penalty = int(
         source_card.effect.value if source_card and source_card.effect else -3
     )

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -193,6 +193,29 @@ def _resume_swap(state: GameState, side: Side, choice: str | None) -> GameState:
     )
 
 
+def _resume_salvage(state: GameState, side: Side, choice: str | None) -> GameState:
+    p_state = get_player_state(state, side)
+    if not p_state.discard:
+        return _finish_interactive_effect(state, "-> 風花の効果: 回収できる捨札がない")
+
+    target = _find_card(p_state.discard, choice)
+    if target is None:
+        return _finish_interactive_effect(state, "-> 風花の効果: 回収しない")
+
+    penalty = -3
+    new_discard = [card for card in p_state.discard if card.id != target.id]
+    state = update_player(
+        state,
+        side,
+        hand=p_state.hand + [target],
+        discard=new_discard,
+        point_modifier=p_state.point_modifier + penalty,
+    )
+    return _finish_interactive_effect(
+        state, f"-> 風花の効果: {target.name}を回収し、ポイント{penalty}"
+    )
+
+
 def _resume_removal(state: GameState, side: Side, choice: str | None) -> GameState:
     if choice not in (None, "activate", "yes", "true"):
         return _finish_interactive_effect(state, "-> ジュリアの効果: 発動しない")
@@ -235,6 +258,8 @@ def resume_pending_effect(state: GameState, choice: str | None = None) -> GameSt
         return _resume_swap(state, side, choice)
     if ctx.effect == "removal":
         return _resume_removal(state, side, choice)
+    if ctx.effect == "salvage":
+        return _resume_salvage(state, side, choice)
 
     return _finish_interactive_effect(state, "-> 選択完了")
 
@@ -823,6 +848,18 @@ def effect_removal(state: GameState, side: Side, card: Card) -> GameState:
     )
     return replace(
         state, battle_log=state.battle_log + [f"{card.name}の効果発動: 発動待機中..."]
+    )
+
+
+@register("salvage")
+def effect_salvage(state: GameState, side: Side, card: Card) -> GameState:
+    ctx = PendingEffectContext(side=side, card_id=card.id, effect="salvage")
+    state = replace(
+        state, phase=Phase.INTERACTIVE_EFFECT, effect_step=0, pending_effect_context=ctx
+    )
+    return replace(
+        state,
+        battle_log=state.battle_log + [f"{card.name}の効果発動: 回収選択待機中..."],
     )
 
 

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -695,6 +695,13 @@ def _choose_npc_pending_effect(
             return "activate"
         return "skip"
 
+    if ctx.effect == "salvage":
+        if not npc.discard:
+            return None
+        if source_card and not npc_strategy.should_activate(source_card, state):
+            return None
+        return npc_strategy.select_target(npc.discard, state).id
+
     return None
 
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -4,6 +4,7 @@ from shadow_bout.effects import calculate_effective_point
 from shadow_bout.engine import (
     continue_round_effect_step,
     proceed_to_next,
+    process_next_effect,
     resolve_npc_pending_effects,
     resolve_round,
     resolve_round_stepwise,
@@ -290,6 +291,38 @@ def test_resume_salvage_effect_uses_card_defined_penalty_value():
     )
 
     state = resolve_round(state, fuka, other)
+    state = resume_round_effect(state, choice="cx1")
+
+    assert state.current_battle.player_point == 8
+
+
+def test_resume_salvage_effect_copy_hand_uses_copied_card_penalty_value():
+    anna = Card(
+        "c4",
+        "杏奈",
+        "あんな",
+        Janken.ROCK,
+        14,
+        Effect(EffectType.COPY_HAND, "copy_hand", None),
+    )
+    salvage = Card(
+        "c41x",
+        "別風花",
+        "べつふうか",
+        Janken.PAPER,
+        10,
+        Effect(EffectType.SALVAGE, "salvage", -6),
+    )
+    recovered = Card("cx1", "recover", "りかば", Janken.PAPER, 5, None)
+    other = Card("cx2", "other", "おざー", Janken.ROCK, 14, None)
+    state = GameState(
+        player=PlayerState(hand=[anna, salvage], discard=[recovered]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, anna, other)
+    state = resume_round_effect(state, choice="c41x")
+    state = process_next_effect(state)
     state = resume_round_effect(state, choice="cx1")
 
     assert state.current_battle.player_point == 8

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -246,6 +246,86 @@ def test_npc_interactive_effect_is_resolved_by_strategy():
     assert state.current_battle.outcome == RoundOutcome.LOSE
 
 
+def test_resume_salvage_effect_recovers_from_discard_with_penalty():
+    fuka = Card(
+        "card_41",
+        "風花",
+        "ふうか",
+        Janken.SCISSORS,
+        13,
+        Effect(EffectType.SALVAGE, "salvage", -3),
+    )
+    recovered = Card("cx1", "recover", "りかば", Janken.PAPER, 5, None)
+    other = Card("cx2", "other", "おざー", Janken.SCISSORS, 13, None)
+    state = GameState(
+        player=PlayerState(hand=[fuka], discard=[recovered]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, fuka, other)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+
+    state = resume_round_effect(state, choice="cx1")
+
+    assert state.phase == Phase.REVEAL
+    assert state.player.hand == [recovered]
+    assert state.player.discard == []
+    assert state.current_battle.player_point == 10
+
+
+def test_resume_salvage_effect_skip_keeps_state_unchanged():
+    fuka = Card(
+        "card_41",
+        "風花",
+        "ふうか",
+        Janken.SCISSORS,
+        13,
+        Effect(EffectType.SALVAGE, "salvage", -3),
+    )
+    recovered = Card("cx1", "recover", "りかば", Janken.PAPER, 5, None)
+    other = Card("cx2", "other", "おざー", Janken.SCISSORS, 13, None)
+    state = GameState(
+        player=PlayerState(hand=[fuka], discard=[recovered]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, fuka, other)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+
+    state = resume_round_effect(state, choice=None)
+
+    assert state.phase == Phase.REVEAL
+    assert state.player.hand == []
+    assert state.player.discard == [recovered]
+    assert state.current_battle.player_point == 13
+
+
+def test_resume_salvage_effect_noops_when_discard_is_empty():
+    fuka = Card(
+        "card_41",
+        "風花",
+        "ふうか",
+        Janken.SCISSORS,
+        13,
+        Effect(EffectType.SALVAGE, "salvage", -3),
+    )
+    other = Card("cx2", "other", "おざー", Janken.SCISSORS, 13, None)
+    state = GameState(
+        player=PlayerState(hand=[fuka], discard=[]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, fuka, other)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+
+    state = resume_round_effect(state, choice="any")
+
+    assert state.phase == Phase.REVEAL
+    assert state.player.hand == []
+    assert state.player.discard == []
+    assert state.current_battle.player_point == 13
+
+
 def test_resume_removal_effect_skips_winner_and_moves_cards():
     julia = Card(
         "c50",

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -273,6 +273,28 @@ def test_resume_salvage_effect_recovers_from_discard_with_penalty():
     assert state.current_battle.player_point == 10
 
 
+def test_resume_salvage_effect_uses_card_defined_penalty_value():
+    fuka = Card(
+        "card_41",
+        "風花",
+        "ふうか",
+        Janken.SCISSORS,
+        13,
+        Effect(EffectType.SALVAGE, "salvage", -5),
+    )
+    recovered = Card("cx1", "recover", "りかば", Janken.PAPER, 5, None)
+    other = Card("cx2", "other", "おざー", Janken.SCISSORS, 13, None)
+    state = GameState(
+        player=PlayerState(hand=[fuka], discard=[recovered]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, fuka, other)
+    state = resume_round_effect(state, choice="cx1")
+
+    assert state.current_battle.player_point == 8
+
+
 def test_resume_salvage_effect_skip_keeps_state_unchanged():
     fuka = Card(
         "card_41",


### PR DESCRIPTION
## 概要
- `salvage` 効果を実装し、対話フェーズで捨札回収の選択を処理
- 回収成功時のみ捨札から手札へ移動し、ポイント-3を適用
- NPCの対話効果解決に `salvage` の選択ロジックを追加
- 回収 / skip / 捨札空のテストを追加

## テスト
- `ruff format`
- `ruff check --fix --extend-select I`
- `.venv/bin/python -m pytest`
