### PR TITLE
feat(effects): implement buff_scaling for card_27

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -499,6 +499,18 @@ def effect_buff_next(state: GameState, side: Side, card: Card) -> GameState:
     )
 
 
+@register("buff_scaling")
+def effect_buff_scaling(state: GameState, side: Side, card: Card) -> GameState:
+    p_state = get_player_state(state, side)
+    bonus = state.round_number * 2
+    state = update_player(state, side, point_modifier=p_state.point_modifier + bonus)
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: R{state.round_number}のためポイント+{bonus}"],
+    )
+
+
 @register("debuff")
 def effect_debuff(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -999,6 +999,27 @@ def test_conditional_debuff_next_is_applied_only_on_next_round_for_npc_side():
     assert third_state.player.point_modifier == 0
 
 
+def test_buff_scaling_adds_bonus_by_round_number():
+    sayoko = Card(
+        "card_27",
+        "紗代子",
+        "さよこ",
+        Janken.PAPER,
+        14,
+        Effect(EffectType.BUFF_SCALING, "round scaling", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.PAPER, 14, None)
+
+    for round_number, expected_bonus in ((1, 2), (2, 4), (3, 6), (4, 8)):
+        state = GameState(
+            player=PlayerState(hand=[sayoko]),
+            npc=PlayerState(hand=[other]),
+            round_number=round_number,
+        )
+        state = resolve_round(state, sayoko, other)
+        assert state.player.point_modifier == expected_bonus
+
+
 def test_conditional_debuff_next_does_not_apply_to_wildcard():
     subaru = Card(
         "c47",


### PR DESCRIPTION
## 概要
- `buff_scaling` 効果を実装し、ラウンド数に応じて `+2 / +4 / +6 / +8` を現在ラウンドのポイント補正として付与
- 効果発動ログにラウンド番号と加算値を記録
- R1〜R4 の期待値を検証するテストを追加

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
