### PR TITLE
feat(effects): implement buff_and_peek

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -306,6 +306,28 @@ def effect_buff(state: GameState, side: Side, card: Card) -> GameState:
     )
 
 
+@register("buff_and_peek")
+def effect_buff_and_peek(state: GameState, side: Side, card: Card) -> GameState:
+    p_state = get_player_state(state, side)
+    bonus = int(card.effect.value or 0)
+    state = update_player(state, side, point_modifier=p_state.point_modifier + bonus)
+
+    updated_state = get_player_state(state, side)
+    if not updated_state.deck:
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: ポイント+{bonus}、山札が空のため確認できない"],
+        )
+
+    top_card = updated_state.deck[0]
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: ポイント+{bonus}、山札の一番上は{top_card.name}"],
+    )
+
+
 @register("draw")
 def effect_draw(state: GameState, side: Side, card: Card) -> GameState:
     if card.id in ("card_01", "c1"):

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -730,6 +730,51 @@ def test_steal_draw_effect_noops_when_opponent_deck_is_empty():
     assert state.npc.deck == []
 
 
+def test_buff_and_peek_adds_point_and_logs_top_card():
+    tamaki = Card(
+        "card_40",
+        "環",
+        "たまき",
+        Janken.ROCK,
+        13,
+        Effect(EffectType.BUFF_AND_PEEK, "buff and peek", 2),
+    )
+    other = Card("cx", "other", "おざー", Janken.ROCK, 13, None)
+    top = Card("d1", "でっき1", "でっき1", Janken.PAPER, 1)
+    remain = Card("d2", "でっき2", "でっき2", Janken.SCISSORS, 2)
+    state = GameState(
+        player=PlayerState(hand=[tamaki], deck=[top, remain]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, tamaki, other)
+
+    assert state.player.point_modifier == 2
+    assert state.player.deck == [top, remain]
+    assert any("山札の一番上はでっき1" in log for log in state.battle_log)
+
+
+def test_buff_and_peek_adds_point_when_deck_is_empty():
+    tamaki = Card(
+        "card_40",
+        "環",
+        "たまき",
+        Janken.ROCK,
+        13,
+        Effect(EffectType.BUFF_AND_PEEK, "buff and peek", 2),
+    )
+    other = Card("cx", "other", "おざー", Janken.ROCK, 13, None)
+    state = GameState(
+        player=PlayerState(hand=[tamaki], deck=[]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, tamaki, other)
+
+    assert state.player.point_modifier == 2
+    assert any("山札が空のため確認できない" in log for log in state.battle_log)
+
+
 def test_steal_hand_effect_moves_random_card_from_opponent_hand_to_own_hand():
     random.seed(0)
     rio = Card(


### PR DESCRIPTION
## 概要
- card_40 向けに `buff_and_peek` 効果を実装し、ポイント+2を反映
- 山札の一番上をログに記録（山札が空の場合のログも追加）
- 通常ケースと山札空ケースのテストを追加

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
