### PR TITLE
feat(effects): implement immune effect handling

### DIFF
--- a/shadow_bout/effect_core.py
+++ b/shadow_bout/effect_core.py
@@ -8,6 +8,39 @@ from shadow_bout.effect_scoring import (
 from shadow_bout.effect_utils import get_player_state
 from shadow_bout.models import Card, GameState, Phase, Side
 
+_OPPONENT_TARGETING_EFFECTS = frozenset(
+    {
+        "ban",
+        "conditional_debuff_next",
+        "curse",
+        "debuff",
+        "debuff_conditional",
+        "debuff_persistent",
+        "force_play",
+        "negate",
+        "reveal",
+        "reveal_all",
+        "set_point",
+        "steal_draw",
+        "steal_hand",
+    }
+)
+
+
+def _is_immune_active(state: GameState, side: Side) -> bool:
+    battle = state.current_battle
+    if battle is None:
+        return False
+    card = battle.player_card if side == Side.PLAYER else battle.npc_card
+    return bool(card.effect and card.effect.type.value == "immune")
+
+
+def _is_blocked_by_immune(state: GameState, side: Side, card: Card) -> bool:
+    if not card.effect or card.effect.type.value not in _OPPONENT_TARGETING_EFFECTS:
+        return False
+    opp_side = Side.NPC if side == Side.PLAYER else Side.PLAYER
+    return _is_immune_active(state, opp_side)
+
 
 def init_effect_resolution(state: GameState, p_card: Card, n_card: Card) -> GameState:
     # Sort order: smaller base_point first, then kana.
@@ -39,6 +72,15 @@ def process_next_effect(state: GameState) -> GameState:
         if not card.effect:
             current_state = replace(
                 current_state, effect_queue=current_state.effect_queue[1:]
+            )
+            continue
+
+        if _is_blocked_by_immune(current_state, side, card):
+            current_state = replace(
+                current_state,
+                effect_queue=current_state.effect_queue[1:],
+                battle_log=current_state.battle_log
+                + [f"{card.name}の効果発動: 相手のimmuneにより無効"],
             )
             continue
 
@@ -88,6 +130,14 @@ def process_next_effect_step(state: GameState) -> GameState:
 
         p_state = get_player_state(current_state, side)
         if p_state.effect_negated or not card.effect:
+            break
+
+        if _is_blocked_by_immune(current_state, side, card):
+            current_state = replace(
+                current_state,
+                battle_log=current_state.battle_log
+                + [f"{card.name}の効果発動: 相手のimmuneにより無効"],
+            )
             break
 
         handler = get_effect_handler(card.effect.type.value)

--- a/shadow_bout/effect_core.py
+++ b/shadow_bout/effect_core.py
@@ -18,6 +18,7 @@ _OPPONENT_TARGETING_EFFECTS = frozenset(
         "debuff_persistent",
         "force_play",
         "negate",
+        "removal",
         "reveal",
         "reveal_all",
         "set_point",

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -73,6 +73,23 @@ def _find_card_by_id(state: GameState, side: Side, card_id: str | None) -> Card 
     )
 
 
+def _is_immune_active(state: GameState, side: Side) -> bool:
+    battle = state.current_battle
+    if battle is None:
+        return False
+
+    card = battle.player_card if side == Side.PLAYER else battle.npc_card
+    return bool(card.effect and card.effect.type.value == "immune")
+
+
+def _is_blocked_by_immune(
+    state: GameState, source_side: Side, target_side: Side
+) -> bool:
+    if source_side == target_side:
+        return False
+    return _is_immune_active(state, target_side)
+
+
 def _parse_card_ids(choice: str | None) -> list[str]:
     if not choice:
         return []
@@ -316,6 +333,15 @@ def effect_null(state: GameState, side: Side, card: Card) -> GameState:
     return state
 
 
+@register("immune")
+def effect_immune(state: GameState, side: Side, card: Card) -> GameState:
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手の戦具効果を受けない"],
+    )
+
+
 @register("buff")
 def effect_buff(state: GameState, side: Side, card: Card) -> GameState:
     p_state = get_player_state(state, side)
@@ -536,6 +562,12 @@ def effect_buff_scaling(state: GameState, side: Side, card: Card) -> GameState:
 @register("debuff")
 def effect_debuff(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _is_blocked_by_immune(state, side, opp_side):
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手のimmuneにより無効"],
+        )
     opp_state = get_player_state(state, opp_side)
 
     if card.id in ("card_04", "c4"):
@@ -577,6 +609,12 @@ def effect_debuff(state: GameState, side: Side, card: Card) -> GameState:
 @register("set_point")
 def effect_set_point(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _is_blocked_by_immune(state, side, opp_side):
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手のimmuneにより無効"],
+        )
     opp_state = get_player_state(state, opp_side)
 
     set_value = int(card.effect.value or 0)
@@ -636,6 +674,12 @@ def effect_conditional_debuff_next(
     state: GameState, side: Side, card: Card
 ) -> GameState:
     opp_side = get_opponent_side(side)
+    if _is_blocked_by_immune(state, side, opp_side):
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手のimmuneにより無効"],
+        )
     opp_state = get_player_state(state, opp_side)
     debuff = int(card.effect.value or 0)
     state = update_player(
@@ -655,6 +699,12 @@ def effect_conditional_debuff_next(
 @register("debuff_persistent")
 def effect_debuff_persistent(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _is_blocked_by_immune(state, side, opp_side):
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手のimmuneにより無効"],
+        )
     opp_state = get_player_state(state, opp_side)
     debuff = int(card.effect.value or 0)
     state = update_player(
@@ -678,6 +728,12 @@ def effect_debuff_persistent(state: GameState, side: Side, card: Card) -> GameSt
 @register("debuff_conditional")
 def effect_debuff_conditional(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _is_blocked_by_immune(state, side, opp_side):
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手のimmuneにより無効"],
+        )
     opp_state = get_player_state(state, opp_side)
     debuff = int(card.effect.value or 0)
 
@@ -727,6 +783,12 @@ def effect_debuff_conditional(state: GameState, side: Side, card: Card) -> GameS
 @register("negate")
 def effect_negate(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _is_blocked_by_immune(state, side, opp_side):
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手のimmuneにより無効"],
+        )
     state = update_player(state, opp_side, effect_negated=True)
     return replace(
         state,
@@ -738,6 +800,12 @@ def effect_negate(state: GameState, side: Side, card: Card) -> GameState:
 @register("force_play")
 def effect_force_play(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _is_blocked_by_immune(state, side, opp_side):
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手のimmuneにより無効"],
+        )
     opp_state = get_player_state(state, opp_side)
     if not opp_state.hand:
         return replace(
@@ -758,6 +826,12 @@ def effect_force_play(state: GameState, side: Side, card: Card) -> GameState:
 @register("ban")
 def effect_ban(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _is_blocked_by_immune(state, side, opp_side):
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手のimmuneにより無効"],
+        )
     opp_state = get_player_state(state, opp_side)
     if not opp_state.hand:
         return replace(

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -166,6 +166,10 @@ def _resume_choose(state: GameState, side: Side, choice: str | None) -> GameStat
         if choice != "activate":
             return _finish_interactive_effect(state, "-> 可憐の効果: 発動しない")
         opp_side = get_opponent_side(side)
+        if _is_blocked_by_immune(state, side, opp_side):
+            return _finish_interactive_effect(
+                state, "-> 可憐の効果: 相手のimmuneにより無効"
+            )
         state = set_must_reveal_played_card_rounds(state, opp_side, rounds=2)
         return _finish_interactive_effect(
             state, "-> 可憐の効果: 相手は2ラウンドの間、出し札を公開"

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1624,3 +1624,36 @@ def test_immune_blocks_steal_hand_and_reveal_and_curse():
     )
     state = resolve_round(state, emily, curse)
     assert state.player.must_reveal_played_card is False
+
+
+def test_immune_blocks_karen_choose_activate_effect():
+    emily = Card(
+        "card_32",
+        "エミリー",
+        "えみりー",
+        Janken.ROCK,
+        13,
+        Effect(EffectType.IMMUNE, "immune", None),
+    )
+    karen = Card(
+        "card_45",
+        "可憐",
+        "かれん",
+        Janken.ROCK,
+        10,
+        Effect(EffectType.CHOOSE, "choose", None),
+    )
+
+    state = GameState(
+        player=PlayerState(hand=[emily]),
+        npc=PlayerState(hand=[karen]),
+    )
+
+    state = resolve_round(state, emily, karen)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+    assert state.pending_effect_context.side == Side.NPC
+
+    state = resume_round_effect(state, choice="activate")
+
+    assert state.phase == Phase.REVEAL
+    assert state.player.must_reveal_played_card_rounds == 0

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1506,3 +1506,121 @@ def test_conditional_buff_does_not_apply_when_opponent_won_total_is_not_higher()
     assert state.current_battle.player_point == 14
     assert state.current_battle.npc_point == 14
     assert any("不発" in log for log in state.battle_log)
+
+
+def test_immune_blocks_opponent_debuff_and_negate_but_allows_own_buff():
+    emily = Card(
+        "card_32",
+        "エミリー",
+        "えみりー",
+        Janken.SCISSORS,
+        13,
+        Effect(EffectType.IMMUNE, "immune", None),
+    )
+    debuff = Card(
+        "card_04",
+        "雪歩",
+        "ゆきほ",
+        Janken.SCISSORS,
+        15,
+        Effect(EffectType.DEBUFF, "debuff", -1),
+    )
+    buff = Card(
+        "c5",
+        "やよい",
+        "やよい",
+        Janken.SCISSORS,
+        16,
+        Effect(EffectType.BUFF, "+5", 5),
+    )
+    negate = Card(
+        "c2",
+        "千早",
+        "ちはや",
+        Janken.SCISSORS,
+        12,
+        Effect(EffectType.NEGATE, "negate", None),
+    )
+
+    state_with_immune = GameState(
+        player=PlayerState(hand=[emily]),
+        npc=PlayerState(hand=[debuff, negate]),
+    )
+    state_with_immune = resolve_round(state_with_immune, emily, debuff)
+
+    assert state_with_immune.current_battle.player_point == 13
+    assert state_with_immune.current_battle.npc_point == 15
+
+    state_without_immune = GameState(
+        player=PlayerState(hand=[buff]),
+        npc=PlayerState(hand=[debuff, negate]),
+    )
+    state_without_immune = resolve_round(state_without_immune, buff, debuff)
+
+    assert state_without_immune.current_battle.player_point == 13
+    assert state_without_immune.current_battle.npc_point == 15
+
+    state_immune_vs_negate = GameState(
+        player=PlayerState(hand=[emily]),
+        npc=PlayerState(hand=[negate]),
+    )
+    state_immune_vs_negate = resolve_round(state_immune_vs_negate, emily, negate)
+
+    assert state_immune_vs_negate.player.effect_negated is False
+
+
+def test_immune_blocks_steal_hand_and_reveal_and_curse():
+    emily = Card(
+        "card_32",
+        "エミリー",
+        "えみりー",
+        Janken.ROCK,
+        13,
+        Effect(EffectType.IMMUNE, "immune", None),
+    )
+    steal = Card(
+        "card_20",
+        "可奈",
+        "かな",
+        Janken.ROCK,
+        12,
+        Effect(EffectType.STEAL_HAND, "steal_hand", None),
+    )
+    reveal = Card(
+        "card_09",
+        "あずさ",
+        "あずさ",
+        Janken.ROCK,
+        12,
+        Effect(EffectType.REVEAL, "reveal", None),
+    )
+    curse = Card(
+        "c51",
+        "呪い",
+        "のろい",
+        Janken.ROCK,
+        12,
+        Effect(EffectType.CURSE, "curse", None),
+    )
+    extra = Card("x1", "extra", "えくすとら", Janken.PAPER, 1)
+
+    state = GameState(
+        player=PlayerState(hand=[emily, extra]),
+        npc=PlayerState(hand=[steal]),
+    )
+    state = resolve_round(state, emily, steal)
+    assert state.player.hand == [extra]
+
+    state = GameState(
+        player=PlayerState(hand=[emily, extra]),
+        npc=PlayerState(hand=[reveal]),
+    )
+    state = resolve_round(state, emily, reveal)
+    assert state.player.revealed_card_ids == frozenset()
+
+    state = GameState(
+        player=PlayerState(hand=[emily]),
+        npc=PlayerState(hand=[curse]),
+    )
+    state = resolve_round(state, emily, curse)
+    assert state.player.must_reveal_played_card is False

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1657,3 +1657,34 @@ def test_immune_blocks_karen_choose_activate_effect():
 
     assert state.phase == Phase.REVEAL
     assert state.player.must_reveal_played_card_rounds == 0
+
+
+def test_immune_blocks_removal_effect():
+    emily = Card(
+        "card_32",
+        "エミリー",
+        "えみりー",
+        Janken.SCISSORS,
+        13,
+        Effect(EffectType.IMMUNE, "immune", None),
+    )
+    julia = Card(
+        "c50",
+        "ジュリア",
+        "じゅりあ",
+        Janken.SCISSORS,
+        12,
+        Effect(EffectType.REMOVAL, "removal", None),
+    )
+
+    state = GameState(
+        player=PlayerState(hand=[emily]),
+        npc=PlayerState(hand=[julia]),
+    )
+
+    state = resolve_round(state, emily, julia)
+
+    assert state.phase == Phase.REVEAL
+    assert state.removal_activated is False
+    assert state.current_battle.outcome == RoundOutcome.WIN
+    assert state.player.won_cards == [julia]


### PR DESCRIPTION
## 概要
- card_32（エミリー）の `immune` 効果を実装
- 効果解決時に、相手から受ける対象効果を `immune` で無効化する判定を追加
- `immune` の有無で同一条件比較するテストを追加

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
