### PR TITLE
feat(effects): implement choose_multiple for card_29

### DIFF
--- a/app.py
+++ b/app.py
@@ -314,6 +314,32 @@ def render_pending_effect_form(game_state):
             submit_effect_choice(game_state, choice)
         return
 
+    if ctx.effect == "choose_multiple":
+        options: list[str] = []
+        if player.hand:
+            options.append("discard_buff")
+        if player.deck:
+            options.append("draw_debuff")
+
+        if not options:
+            st.info("発動可能な効果がありません。")
+            if st.button("次へ", type="primary", use_container_width=True):
+                submit_effect_choice(game_state, "")
+            return
+
+        selected = st.multiselect(
+            "海美の効果（1つまたは両方を選択）",
+            options,
+            format_func=lambda value: {
+                "discard_buff": "手札1枚を捨て札に置いてポイント+5",
+                "draw_debuff": "山札から1枚引いてポイント-2",
+            }[value],
+            key=f"choose_multiple_{game_state.round_number}_{ctx.card_id}_{ctx.side.value}",
+        )
+        if st.button("この効果を決定", type="primary", use_container_width=True):
+            submit_effect_choice(game_state, ",".join(selected))
+        return
+
     if ctx.effect == "search_and_swap":
         mode = st.radio(
             "千鶴の効果",

--- a/app.py
+++ b/app.py
@@ -336,7 +336,15 @@ def render_pending_effect_form(game_state):
             }[value],
             key=f"choose_multiple_{game_state.round_number}_{ctx.card_id}_{ctx.side.value}",
         )
-        if st.button("この効果を決定", type="primary", use_container_width=True):
+        is_ready = len(selected) > 0
+        if not is_ready:
+            st.caption("1つ以上選んでください。")
+        if st.button(
+            "この効果を決定",
+            type="primary",
+            disabled=not is_ready,
+            use_container_width=True,
+        ):
             submit_effect_choice(game_state, ",".join(selected))
         return
 

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -265,6 +265,13 @@ def _resume_choose_multiple(
     state: GameState, side: Side, choice: str | None
 ) -> GameState:
     p_state = get_player_state(state, side)
+    if choice is None:
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + ["-> 海美の効果: 効果を1つ以上選択してください"],
+        )
+
     selected = set(_parse_card_ids(choice))
 
     can_discard = bool(p_state.hand)

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -261,6 +261,54 @@ def _resume_reorder(state: GameState, side: Side, choice: str | None) -> GameSta
     return _finish_interactive_effect(state, "-> 茜の効果: 山札の順番を入れ替えた")
 
 
+def _resume_choose_multiple(
+    state: GameState, side: Side, choice: str | None
+) -> GameState:
+    p_state = get_player_state(state, side)
+    selected = set(_parse_card_ids(choice))
+
+    can_discard = bool(p_state.hand)
+    can_draw = bool(p_state.deck)
+
+    do_discard = "discard_buff" in selected and can_discard
+    do_draw = "draw_debuff" in selected and can_draw
+
+    if not do_discard and not do_draw:
+        return _finish_interactive_effect(state, "-> 海美の効果: 発動可能な効果がない")
+
+    logs: list[str] = []
+
+    if do_discard:
+        discarded = p_state.hand[0]
+        p_state = replace(
+            p_state,
+            hand=p_state.hand[1:],
+            discard=p_state.discard + [discarded],
+            point_modifier=p_state.point_modifier + 5,
+        )
+        logs.append(f"{discarded.name}を捨札にしてポイント+5")
+
+    if do_draw:
+        drawn = p_state.deck[0]
+        p_state = replace(
+            p_state,
+            hand=p_state.hand + [drawn],
+            deck=p_state.deck[1:],
+            point_modifier=p_state.point_modifier - 2,
+        )
+        logs.append(f"{drawn.name}を1枚引いてポイント-2")
+
+    state = update_player(
+        state,
+        side,
+        hand=p_state.hand,
+        deck=p_state.deck,
+        discard=p_state.discard,
+        point_modifier=p_state.point_modifier,
+    )
+    return _finish_interactive_effect(state, f"-> 海美の効果: {'、'.join(logs)}")
+
+
 def _resume_removal(state: GameState, side: Side, choice: str | None) -> GameState:
     if choice not in (None, "activate", "yes", "true"):
         return _finish_interactive_effect(state, "-> ジュリアの効果: 発動しない")
@@ -307,6 +355,8 @@ def resume_pending_effect(state: GameState, choice: str | None = None) -> GameSt
         return _resume_salvage(state, side, choice)
     if ctx.effect == "reorder":
         return _resume_reorder(state, side, choice)
+    if ctx.effect == "choose_multiple":
+        return _resume_choose_multiple(state, side, choice)
 
     return _finish_interactive_effect(state, "-> 選択完了")
 
@@ -901,6 +951,26 @@ def effect_choose(state: GameState, side: Side, card: Card) -> GameState:
     )
     return replace(
         state, battle_log=state.battle_log + [f"{card.name}の効果発動: 選択待機中..."]
+    )
+
+
+@register("choose_multiple")
+def effect_choose_multiple(state: GameState, side: Side, card: Card) -> GameState:
+    p_state = get_player_state(state, side)
+    if not p_state.hand and not p_state.deck:
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 発動可能な効果がないため不発"],
+        )
+
+    ctx = PendingEffectContext(side=side, card_id=card.id, effect="choose_multiple")
+    state = replace(
+        state, phase=Phase.INTERACTIVE_EFFECT, effect_step=0, pending_effect_context=ctx
+    )
+    return replace(
+        state,
+        battle_log=state.battle_log + [f"{card.name}の効果発動: 複数選択待機中..."],
     )
 
 

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -265,7 +265,7 @@ def _resume_choose_multiple(
     state: GameState, side: Side, choice: str | None
 ) -> GameState:
     p_state = get_player_state(state, side)
-    if choice is None:
+    if not choice:
         return replace(
             state,
             battle_log=state.battle_log

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -708,6 +708,14 @@ def _choose_npc_pending_effect(
         random.shuffle(shuffled)
         return ",".join(card.id for card in shuffled)
 
+    if ctx.effect == "choose_multiple":
+        choices: list[str] = []
+        if npc.hand:
+            choices.append("discard_buff")
+        if npc.deck:
+            choices.append("draw_debuff")
+        return ",".join(choices) if choices else None
+
     return None
 
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -652,6 +652,31 @@ def test_umi_choose_multiple_no_available_option_is_safe():
     assert state.player.point_modifier == 0
 
 
+def test_umi_choose_multiple_none_choice_keeps_interactive():
+    umi = Card(
+        "card_29",
+        "海美",
+        "うみ",
+        Janken.SCISSORS,
+        14,
+        Effect(EffectType.CHOOSE_MULTIPLE, "choose_multiple", None),
+    )
+    hand_card = Card("h1", "手札", "てふだ", Janken.ROCK, 5)
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 14, None)
+    state = GameState(
+        player=PlayerState(hand=[umi, hand_card]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, umi, other)
+    state = resume_round_effect(state, choice=None)
+
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+    assert state.pending_effect_context is not None
+    assert state.pending_effect_context.effect == "choose_multiple"
+    assert state.player.point_modifier == 0
+
+
 def test_ami_restart_does_not_duplicate_played_cards():
     ami = Card(
         "c11",

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -677,6 +677,31 @@ def test_umi_choose_multiple_none_choice_keeps_interactive():
     assert state.player.point_modifier == 0
 
 
+def test_umi_choose_multiple_empty_choice_keeps_interactive():
+    umi = Card(
+        "card_29",
+        "海美",
+        "うみ",
+        Janken.SCISSORS,
+        14,
+        Effect(EffectType.CHOOSE_MULTIPLE, "choose_multiple", None),
+    )
+    hand_card = Card("h1", "手札", "てふだ", Janken.ROCK, 5)
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 14, None)
+    state = GameState(
+        player=PlayerState(hand=[umi, hand_card]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, umi, other)
+    state = resume_round_effect(state, choice="")
+
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+    assert state.pending_effect_context is not None
+    assert state.pending_effect_context.effect == "choose_multiple"
+    assert state.player.point_modifier == 0
+
+
 def test_ami_restart_does_not_duplicate_played_cards():
     ami = Card(
         "c11",

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -556,6 +556,102 @@ def test_karen_choose_activate_sets_must_reveal_on_opponent():
     assert state.npc.must_reveal_played_card_rounds == 2
 
 
+def test_umi_choose_multiple_discard_only_applies_buff():
+    umi = Card(
+        "card_29",
+        "海美",
+        "うみ",
+        Janken.SCISSORS,
+        14,
+        Effect(EffectType.CHOOSE_MULTIPLE, "choose_multiple", None),
+    )
+    hand_card = Card("h1", "手札", "てふだ", Janken.ROCK, 5)
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 14, None)
+    state = GameState(
+        player=PlayerState(hand=[umi, hand_card]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, umi, other)
+    state = resume_round_effect(state, choice="discard_buff")
+
+    assert state.player.point_modifier == 5
+    assert state.player.hand == []
+    assert state.player.discard == [hand_card, umi]
+
+
+def test_umi_choose_multiple_draw_only_applies_debuff():
+    umi = Card(
+        "card_29",
+        "海美",
+        "うみ",
+        Janken.SCISSORS,
+        14,
+        Effect(EffectType.CHOOSE_MULTIPLE, "choose_multiple", None),
+    )
+    draw_card = Card("d1", "山札", "やまふだ", Janken.PAPER, 6)
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 14, None)
+    state = GameState(
+        player=PlayerState(hand=[umi], deck=[draw_card]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, umi, other)
+    state = resume_round_effect(state, choice="draw_debuff")
+
+    assert state.player.point_modifier == -2
+    assert state.player.hand == [draw_card]
+    assert state.player.deck == []
+
+
+def test_umi_choose_multiple_both_applies_sum_without_order_dependency():
+    umi = Card(
+        "card_29",
+        "海美",
+        "うみ",
+        Janken.SCISSORS,
+        14,
+        Effect(EffectType.CHOOSE_MULTIPLE, "choose_multiple", None),
+    )
+    hand_card = Card("h1", "手札", "てふだ", Janken.ROCK, 5)
+    draw_card = Card("d1", "山札", "やまふだ", Janken.PAPER, 6)
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 14, None)
+    state = GameState(
+        player=PlayerState(hand=[umi, hand_card], deck=[draw_card]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, umi, other)
+    state = resume_round_effect(state, choice="draw_debuff,discard_buff")
+
+    assert state.player.point_modifier == 3
+    assert state.player.hand == [draw_card]
+    assert state.player.deck == []
+    assert state.player.discard == [hand_card, umi]
+
+
+def test_umi_choose_multiple_no_available_option_is_safe():
+    umi = Card(
+        "card_29",
+        "海美",
+        "うみ",
+        Janken.SCISSORS,
+        14,
+        Effect(EffectType.CHOOSE_MULTIPLE, "choose_multiple", None),
+    )
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 14, None)
+    state = GameState(
+        player=PlayerState(hand=[umi]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, umi, other)
+
+    assert state.phase == Phase.REVEAL
+    assert state.pending_effect_context is None
+    assert state.player.point_modifier == 0
+
+
 def test_ami_restart_does_not_duplicate_played_cards():
     ami = Card(
         "c11",


### PR DESCRIPTION
## 概要
- 既存コミット `9dc4b23`（`feat(effects): implement choose_multiple for card_29`）をそのまま作業ブランチ `feat-choose-multiple-umi` にて push しました。
- 追加の修正やコミットは行っていません（ユーザー指示どおり）。

## テスト
- 追加実行なし（コミット済み内容のみを push / PR 作成）。
