### PR TITLE
feat(effects): implement swap_opponent for card_36

### DIFF
--- a/app.py
+++ b/app.py
@@ -416,6 +416,42 @@ def render_pending_effect_form(game_state):
             submit_effect_choice(game_state, choice)
         return
 
+    if ctx.effect == "swap_opponent":
+        opponent = game_state.npc if ctx.side == Side.PLAYER else game_state.player
+        if not opponent.hand:
+            st.info("相手の手札がないため入れ替えできません。")
+            if st.button("次へ", type="primary", use_container_width=True):
+                submit_effect_choice(game_state, None)
+            return
+
+        if ctx.step == 0:
+            st.info("相手手札をランダムに1枚確認します。")
+            if st.button("確認する", type="primary", use_container_width=True):
+                submit_effect_choice(game_state, "reveal")
+            return
+
+        target_id = ctx.payload.get("target_id")
+        target = next((card for card in opponent.hand if card.id == target_id), None)
+        if target is None:
+            st.warning("確認したカードが見つかりません。")
+            if st.button("次へ", type="primary", use_container_width=True):
+                submit_effect_choice(game_state, None)
+            return
+
+        st.write(f"確認したカード: **{target.name}**（{target.id}）")
+        mode = st.radio(
+            "可奈の効果",
+            ["swap", "skip"],
+            format_func=lambda value: {
+                "swap": "このカードと相手の場カードを入れ替える",
+                "skip": "入れ替えない",
+            }[value],
+            horizontal=True,
+        )
+        if st.button("決定", type="primary", use_container_width=True):
+            submit_effect_choice(game_state, "swap" if mode == "swap" else None)
+        return
+
     if ctx.effect == "removal":
         choice = st.radio(
             "ジュリアの効果",

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -217,16 +217,30 @@ def _resume_swap(state: GameState, side: Side, choice: str | None) -> GameState:
 def _resume_swap_opponent(
     state: GameState, side: Side, choice: str | None
 ) -> GameState:
+    ctx = state.pending_effect_context
     opp_side = get_opponent_side(side)
     opp_state = get_player_state(state, opp_side)
     if not opp_state.hand:
         return _finish_interactive_effect(
             state, "-> 可奈の効果: 相手の手札がないため入れ替えられない"
         )
+    if ctx and ctx.step == 0:
+        target = random.choice(opp_state.hand)
+        next_ctx = replace(ctx, step=1, payload={**ctx.payload, "target_id": target.id})
+        return replace(
+            state,
+            pending_effect_context=next_ctx,
+            battle_log=state.battle_log
+            + [f"-> 可奈の効果: 相手手札から{target.name}を確認した"],
+        )
+
+    target = _find_card(opp_state.hand, ctx.payload.get("target_id") if ctx else None)
+    if target is None:
+        return _finish_interactive_effect(
+            state, "-> 可奈の効果: 確認したカードが手札にないため入れ替えない"
+        )
     if choice != "swap":
         return _finish_interactive_effect(state, "-> 可奈の効果: 入れ替えない")
-
-    target = random.choice(opp_state.hand)
     res = state.current_battle
     if opp_side == Side.PLAYER:
         old_card = res.player_card

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -214,6 +214,38 @@ def _resume_swap(state: GameState, side: Side, choice: str | None) -> GameState:
     )
 
 
+def _resume_swap_opponent(
+    state: GameState, side: Side, choice: str | None
+) -> GameState:
+    opp_side = get_opponent_side(side)
+    opp_state = get_player_state(state, opp_side)
+    if not opp_state.hand:
+        return _finish_interactive_effect(
+            state, "-> 可奈の効果: 相手の手札がないため入れ替えられない"
+        )
+    if choice != "swap":
+        return _finish_interactive_effect(state, "-> 可奈の効果: 入れ替えない")
+
+    target = random.choice(opp_state.hand)
+    res = state.current_battle
+    if opp_side == Side.PLAYER:
+        old_card = res.player_card
+        new_res = replace(res, player_card=target)
+    else:
+        old_card = res.npc_card
+        new_res = replace(res, npc_card=target)
+
+    new_opp_hand = [card for card in opp_state.hand if card.id != target.id] + [
+        old_card
+    ]
+    state = update_player(state, opp_side, hand=new_opp_hand)
+    state = replace(state, current_battle=new_res)
+    return _finish_interactive_effect(
+        state,
+        f"-> 可奈の効果: 相手手札を確認し、{old_card.name}と{target.name}を入れ替え",
+    )
+
+
 def _resume_salvage(state: GameState, side: Side, choice: str | None) -> GameState:
     p_state = get_player_state(state, side)
     if not p_state.discard:
@@ -356,6 +388,8 @@ def resume_pending_effect(state: GameState, choice: str | None = None) -> GameSt
         return _resume_search_and_swap(state, side, choice)
     if ctx.effect == "swap":
         return _resume_swap(state, side, choice)
+    if ctx.effect == "swap_opponent":
+        return _resume_swap_opponent(state, side, choice)
     if ctx.effect == "removal":
         return _resume_removal(state, side, choice)
     if ctx.effect == "salvage":
@@ -1045,6 +1079,19 @@ def effect_swap(state: GameState, side: Side, card: Card) -> GameState:
     return replace(
         state,
         battle_log=state.battle_log + [f"{card.name}の効果発動: 入れ替え選択待機中..."],
+    )
+
+
+@register("swap_opponent")
+def effect_swap_opponent(state: GameState, side: Side, card: Card) -> GameState:
+    ctx = PendingEffectContext(side=side, card_id=card.id, effect="swap_opponent")
+    state = replace(
+        state, phase=Phase.INTERACTIVE_EFFECT, effect_step=0, pending_effect_context=ctx
+    )
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手手札確認・入れ替え待機中..."],
     )
 
 

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -691,6 +691,14 @@ def _choose_npc_pending_effect(
             return None
         return npc_strategy.select_target(npc.hand, state).id
 
+    if ctx.effect == "swap_opponent":
+        player = get_player_state(state, Side.PLAYER)
+        if not player.hand:
+            return None
+        if npc_strategy.choose_effect(["swap", "skip"], state) == "skip":
+            return None
+        return "swap"
+
     if ctx.effect == "removal":
         if source_card and npc_strategy.should_activate(source_card, state):
             return "activate"

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1021,6 +1021,77 @@ def test_steal_hand_effect_noops_when_opponent_hand_is_empty():
     assert state.npc.hand == []
 
 
+def test_swap_opponent_effect_swaps_with_random_opponent_hand_card():
+    random.seed(0)
+    kana = Card(
+        "card_36",
+        "可奈",
+        "かな",
+        Janken.PAPER,
+        13,
+        Effect(EffectType.SWAP_OPPONENT, "swap opponent", None),
+    )
+    npc_card = Card("n_battle", "n_battle", "えぬ場", Janken.PAPER, 10, None)
+    hand1 = Card("n_h1", "n_h1", "えぬ手1", Janken.ROCK, 2, None)
+    hand2 = Card("n_h2", "n_h2", "えぬ手2", Janken.SCISSORS, 3, None)
+    state = GameState(
+        player=PlayerState(hand=[kana]),
+        npc=PlayerState(hand=[npc_card, hand1, hand2]),
+    )
+
+    state = resolve_round(state, kana, npc_card)
+    state = resume_round_effect(state, choice="swap")
+
+    assert state.current_battle.npc_card.id in {hand1.id, hand2.id}
+    assert npc_card in state.npc.hand
+    assert len(state.npc.hand) == 2
+
+
+def test_swap_opponent_effect_can_skip():
+    kana = Card(
+        "card_36",
+        "可奈",
+        "かな",
+        Janken.PAPER,
+        13,
+        Effect(EffectType.SWAP_OPPONENT, "swap opponent", None),
+    )
+    npc_card = Card("n_battle", "n_battle", "えぬ場", Janken.PAPER, 10, None)
+    hand1 = Card("n_h1", "n_h1", "えぬ手1", Janken.ROCK, 2, None)
+    state = GameState(
+        player=PlayerState(hand=[kana]),
+        npc=PlayerState(hand=[npc_card, hand1]),
+    )
+
+    state = resolve_round(state, kana, npc_card)
+    state = resume_round_effect(state, choice=None)
+
+    assert state.current_battle.npc_card == npc_card
+    assert state.npc.hand == [hand1]
+
+
+def test_swap_opponent_effect_noops_when_opponent_hand_is_empty():
+    kana = Card(
+        "card_36",
+        "可奈",
+        "かな",
+        Janken.PAPER,
+        13,
+        Effect(EffectType.SWAP_OPPONENT, "swap opponent", None),
+    )
+    npc_card = Card("n_battle", "n_battle", "えぬ場", Janken.PAPER, 10, None)
+    state = GameState(
+        player=PlayerState(hand=[kana]),
+        npc=PlayerState(hand=[npc_card]),
+    )
+
+    state = resolve_round(state, kana, npc_card)
+    state = resume_round_effect(state, choice="swap")
+
+    assert state.current_battle.npc_card == npc_card
+    assert state.npc.hand == []
+
+
 def test_draw_effect_draws_two_cards_for_both_sides():
     emily = Card(
         "card_20",

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1040,6 +1040,7 @@ def test_swap_opponent_effect_swaps_with_random_opponent_hand_card():
     )
 
     state = resolve_round(state, kana, npc_card)
+    state = resume_round_effect(state, choice="reveal")
     state = resume_round_effect(state, choice="swap")
 
     assert state.current_battle.npc_card.id in {hand1.id, hand2.id}
@@ -1064,6 +1065,7 @@ def test_swap_opponent_effect_can_skip():
     )
 
     state = resolve_round(state, kana, npc_card)
+    state = resume_round_effect(state, choice="reveal")
     state = resume_round_effect(state, choice=None)
 
     assert state.current_battle.npc_card == npc_card


### PR DESCRIPTION
## 概要
- `swap_opponent`（card_36 可奈）実装コミットを `feat-swap-opponent` ブランチとして push しました。
- 実装内容
  - `@register("swap_opponent")` を追加
  - 相手手札ランダム1枚との入れ替え（任意）を追加
  - 相手手札空時の no-op を追加
  - NPC 側の `swap_opponent` 解決を追加
- テスト追加
  - swapする / しない / 相手手札空

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest
