### PR TITLE
feat(effects): implement immune effect

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -161,6 +161,10 @@ def _resume_choose(state: GameState, side: Side, choice: str | None) -> GameStat
     if variant == "karen_choose":
         if choice != "activate":
             return _finish_interactive_effect(state, "-> 可憐の効果: 発動しない")
+        if _opponent_is_immune(state, side):
+            return _finish_interactive_effect(
+                state, "-> 可憐の効果: 相手は戦具効果を受けないため不発"
+            )
         opp_side = get_opponent_side(side)
         state = set_must_reveal_played_card_rounds(state, opp_side, rounds=2)
         return _finish_interactive_effect(

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -7,6 +7,7 @@ from shadow_bout.effect_utils import (
     clear_forced_card_id,
     get_opponent_side,
     get_player_state,
+    is_immune_to_opponent_effect,
     set_must_reveal_played_card,
     set_must_reveal_played_card_rounds,
     update_player,
@@ -77,6 +78,18 @@ def _parse_card_ids(choice: str | None) -> list[str]:
     if not choice:
         return []
     return [card_id for card_id in choice.split(",") if card_id]
+
+
+def _immune_blocked_state(state: GameState, card: Card) -> GameState:
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手は戦具効果を受けないため不発"],
+    )
+
+
+def _opponent_is_immune(state: GameState, side: Side) -> bool:
+    return is_immune_to_opponent_effect(state, side, get_opponent_side(side))
 
 
 def _resume_choose(state: GameState, side: Side, choice: str | None) -> GameState:
@@ -219,6 +232,12 @@ def _resume_swap_opponent(
 ) -> GameState:
     ctx = state.pending_effect_context
     opp_side = get_opponent_side(side)
+    source_card = _find_card_by_id(state, side, ctx.card_id if ctx else None)
+    if source_card and is_immune_to_opponent_effect(state, side, opp_side):
+        return _finish_interactive_effect(
+            state, f"-> {source_card.name}の効果: 相手は戦具効果を受けないため不発"
+        )
+
     opp_state = get_player_state(state, opp_side)
     if not opp_state.hand:
         return _finish_interactive_effect(
@@ -366,6 +385,13 @@ def _resume_removal(state: GameState, side: Side, choice: str | None) -> GameSta
     if choice not in (None, "activate", "yes", "true"):
         return _finish_interactive_effect(state, "-> ジュリアの効果: 発動しない")
 
+    ctx = state.pending_effect_context
+    source_card = _find_card_by_id(state, side, ctx.card_id if ctx else None)
+    if source_card and _opponent_is_immune(state, side):
+        return _finish_interactive_effect(
+            state, f"-> {source_card.name}の効果: 相手は戦具効果を受けないため不発"
+        )
+
     res = state.current_battle
     if side == Side.PLAYER:
         own_state = state.player
@@ -421,6 +447,15 @@ def effect_null(state: GameState, side: Side, card: Card) -> GameState:
     return state
 
 
+@register("immune")
+def effect_immune(state: GameState, side: Side, card: Card) -> GameState:
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手の戦具効果を受けない"],
+    )
+
+
 @register("buff")
 def effect_buff(state: GameState, side: Side, card: Card) -> GameState:
     p_state = get_player_state(state, side)
@@ -471,6 +506,15 @@ def effect_draw(state: GameState, side: Side, card: Card) -> GameState:
         )
 
         opp_side = get_opponent_side(side)
+        if _opponent_is_immune(state, side):
+            return replace(
+                state,
+                battle_log=state.battle_log
+                + [
+                    f"{card.name}の効果発動: 自分は{len(own_drawn)}枚ドロー。相手は戦具効果を受けないため対象外"
+                ],
+            )
+
         opp_state = get_player_state(state, opp_side)
         opp_merged_deck = opp_state.deck + opp_state.hand
         random.shuffle(opp_merged_deck)
@@ -502,6 +546,15 @@ def effect_draw(state: GameState, side: Side, card: Card) -> GameState:
     )
 
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [
+                f"{card.name}の効果発動: 自分は{len(own_drawn)}枚ドロー。相手は戦具効果を受けないため対象外"
+            ],
+        )
+
     opp_state = get_player_state(state, opp_side)
     opp_drawn = opp_state.deck[:draw_count]
     state = update_player(
@@ -553,6 +606,9 @@ def effect_draw_dynamic(state: GameState, side: Side, card: Card) -> GameState:
 @register("steal_draw")
 def effect_steal_draw(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     opp_state = get_player_state(state, opp_side)
 
     if not opp_state.deck:
@@ -588,6 +644,9 @@ def effect_steal_draw(state: GameState, side: Side, card: Card) -> GameState:
 @register("steal_hand")
 def effect_steal_hand(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     opp_state = get_player_state(state, opp_side)
 
     if not opp_state.hand:
@@ -663,6 +722,9 @@ def effect_buff_scaling(state: GameState, side: Side, card: Card) -> GameState:
 @register("debuff")
 def effect_debuff(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     opp_state = get_player_state(state, opp_side)
 
     if card.id in ("card_04", "c4"):
@@ -704,6 +766,9 @@ def effect_debuff(state: GameState, side: Side, card: Card) -> GameState:
 @register("set_point")
 def effect_set_point(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     opp_state = get_player_state(state, opp_side)
 
     set_value = int(card.effect.value or 0)
@@ -763,6 +828,9 @@ def effect_conditional_debuff_next(
     state: GameState, side: Side, card: Card
 ) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     opp_state = get_player_state(state, opp_side)
     debuff = int(card.effect.value or 0)
     state = update_player(
@@ -782,6 +850,9 @@ def effect_conditional_debuff_next(
 @register("debuff_persistent")
 def effect_debuff_persistent(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     opp_state = get_player_state(state, opp_side)
     debuff = int(card.effect.value or 0)
     state = update_player(
@@ -805,6 +876,9 @@ def effect_debuff_persistent(state: GameState, side: Side, card: Card) -> GameSt
 @register("debuff_conditional")
 def effect_debuff_conditional(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     opp_state = get_player_state(state, opp_side)
     debuff = int(card.effect.value or 0)
 
@@ -854,6 +928,9 @@ def effect_debuff_conditional(state: GameState, side: Side, card: Card) -> GameS
 @register("negate")
 def effect_negate(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     state = update_player(state, opp_side, effect_negated=True)
     return replace(
         state,
@@ -865,6 +942,9 @@ def effect_negate(state: GameState, side: Side, card: Card) -> GameState:
 @register("force_play")
 def effect_force_play(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     opp_state = get_player_state(state, opp_side)
     if not opp_state.hand:
         return replace(
@@ -885,6 +965,9 @@ def effect_force_play(state: GameState, side: Side, card: Card) -> GameState:
 @register("ban")
 def effect_ban(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     opp_state = get_player_state(state, opp_side)
     if not opp_state.hand:
         return replace(
@@ -916,6 +999,9 @@ def effect_ban(state: GameState, side: Side, card: Card) -> GameState:
 @register("reveal")
 def effect_reveal(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     opp_state = get_player_state(state, opp_side)
     if not opp_state.hand:
         return state
@@ -933,6 +1019,9 @@ def effect_reveal(state: GameState, side: Side, card: Card) -> GameState:
 @register("reveal_all")
 def effect_reveal_all(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     opp_state = get_player_state(state, opp_side)
     new_revealed = opp_state.revealed_card_ids | {
         hand_card.id for hand_card in opp_state.hand
@@ -952,6 +1041,9 @@ def effect_reveal_all(state: GameState, side: Side, card: Card) -> GameState:
 
 @register("restart")
 def effect_restart(state: GameState, side: Side, card: Card) -> GameState:
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     if state.last_restart_round == state.round_number - 1:
         return replace(
             state,
@@ -1098,6 +1190,9 @@ def effect_swap(state: GameState, side: Side, card: Card) -> GameState:
 
 @register("swap_opponent")
 def effect_swap_opponent(state: GameState, side: Side, card: Card) -> GameState:
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     ctx = PendingEffectContext(side=side, card_id=card.id, effect="swap_opponent")
     state = replace(
         state, phase=Phase.INTERACTIVE_EFFECT, effect_step=0, pending_effect_context=ctx
@@ -1111,6 +1206,9 @@ def effect_swap_opponent(state: GameState, side: Side, card: Card) -> GameState:
 
 @register("removal")
 def effect_removal(state: GameState, side: Side, card: Card) -> GameState:
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     ctx = PendingEffectContext(side=side, card_id=card.id, effect="removal")
     state = replace(
         state, phase=Phase.INTERACTIVE_EFFECT, effect_step=0, pending_effect_context=ctx
@@ -1155,6 +1253,9 @@ def effect_reorder(state: GameState, side: Side, card: Card) -> GameState:
 @register("curse")
 def effect_curse(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
     state = set_must_reveal_played_card(state, opp_side, True)
     return replace(
         state,

--- a/shadow_bout/effect_utils.py
+++ b/shadow_bout/effect_utils.py
@@ -1,6 +1,6 @@
 from dataclasses import replace
 
-from shadow_bout.models import GameState, PlayerState, Side
+from shadow_bout.models import Card, GameState, PlayerState, Side
 
 
 def update_player(state: GameState, side: Side, **kwargs) -> GameState:
@@ -18,6 +18,26 @@ def get_player_state(state: GameState, side: Side) -> PlayerState:
 
 def get_opponent_side(side: Side) -> Side:
     return Side.NPC if side == Side.PLAYER else Side.PLAYER
+
+
+def get_battle_card(state: GameState, side: Side) -> Card | None:
+    if state.current_battle is None:
+        return None
+    if side == Side.PLAYER:
+        return state.current_battle.player_card
+    return state.current_battle.npc_card
+
+
+def is_immune_to_opponent_effect(
+    state: GameState, source_side: Side, target_side: Side
+) -> bool:
+    if source_side == target_side:
+        return False
+
+    target_card = get_battle_card(state, target_side)
+    return bool(
+        target_card and target_card.effect and target_card.effect.type.value == "immune"
+    )
 
 
 def add_banned_card_id(state: GameState, side: Side, card_id: str) -> GameState:

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1770,3 +1770,149 @@ def test_conditional_buff_does_not_apply_when_opponent_won_total_is_not_higher()
     assert state.current_battle.player_point == 14
     assert state.current_battle.npc_point == 14
     assert any("不発" in log for log in state.battle_log)
+
+
+def test_immune_blocks_opponent_set_point_compared_with_non_immune_card():
+    azusa = Card(
+        "card_10",
+        "あずさ",
+        "あずさ",
+        Janken.SCISSORS,
+        10,
+        Effect(EffectType.SET_POINT, "set point", 0),
+    )
+    emily = Card(
+        "card_32",
+        "エミリー",
+        "えみりー",
+        Janken.SCISSORS,
+        13,
+        Effect(EffectType.IMMUNE, "immune", None),
+    )
+    other = Card("other", "other", "おざー", Janken.SCISSORS, 13, None)
+
+    immune_state = resolve_round(
+        GameState(player=PlayerState(hand=[emily]), npc=PlayerState(hand=[azusa])),
+        emily,
+        azusa,
+    )
+    non_immune_state = resolve_round(
+        GameState(player=PlayerState(hand=[other]), npc=PlayerState(hand=[azusa])),
+        other,
+        azusa,
+    )
+
+    assert immune_state.current_battle.player_point == 13
+    assert non_immune_state.current_battle.player_point == 0
+    assert any("戦具効果を受けないため不発" in log for log in immune_state.battle_log)
+
+
+def test_immune_blocks_opponent_negate_even_before_immune_resolves():
+    emily = Card(
+        "card_32",
+        "エミリー",
+        "えみりー",
+        Janken.ROCK,
+        13,
+        Effect(EffectType.IMMUNE, "immune", None),
+    )
+    chihaya = Card(
+        "card_02",
+        "千早",
+        "ちはや",
+        Janken.ROCK,
+        11,
+        Effect(EffectType.NEGATE, "negate", None),
+    )
+    state = GameState(player=PlayerState(hand=[emily]), npc=PlayerState(hand=[chihaya]))
+
+    state = resolve_round(state, emily, chihaya)
+
+    assert state.player.effect_negated is False
+    assert any(
+        "エミリーの効果発動: 相手の戦具効果を受けない" in log
+        for log in state.battle_log
+    )
+
+
+def test_immune_blocks_opponent_reveal_all_and_force_play():
+    emily = Card(
+        "card_32",
+        "エミリー",
+        "えみりー",
+        Janken.ROCK,
+        13,
+        Effect(EffectType.IMMUNE, "immune", None),
+    )
+    extra = Card("extra", "extra", "えくすとら", Janken.PAPER, 1, None)
+    takane = Card(
+        "card_08",
+        "貴音",
+        "たかね",
+        Janken.ROCK,
+        15,
+        Effect(EffectType.REVEAL_ALL, "reveal all", None),
+    )
+    force = Card(
+        "card_12",
+        "真美",
+        "まみ",
+        Janken.ROCK,
+        12,
+        Effect(EffectType.FORCE_PLAY, "force play", None),
+    )
+
+    reveal_state = resolve_round(
+        GameState(
+            player=PlayerState(hand=[emily, extra]),
+            npc=PlayerState(hand=[takane]),
+        ),
+        emily,
+        takane,
+    )
+    force_state = resolve_round(
+        GameState(
+            player=PlayerState(hand=[emily, extra]),
+            npc=PlayerState(hand=[force]),
+        ),
+        emily,
+        force,
+    )
+
+    assert reveal_state.player.revealed_card_ids == frozenset()
+    assert reveal_state.revealed_this_round is None
+    assert reveal_state.revealed_this_round_side is None
+    assert force_state.player.forced_card_id is None
+
+
+def test_immune_blocks_only_opponent_side_of_mutual_draw_effect():
+    haruka = Card(
+        "card_01",
+        "春香",
+        "はるか",
+        Janken.SCISSORS,
+        9,
+        Effect(EffectType.DRAW, "mutual draw", 2),
+    )
+    emily = Card(
+        "card_32",
+        "エミリー",
+        "えみりー",
+        Janken.SCISSORS,
+        13,
+        Effect(EffectType.IMMUNE, "immune", None),
+    )
+    own_deck_1 = Card("own1", "own1", "おうん1", Janken.ROCK, 1, None)
+    own_deck_2 = Card("own2", "own2", "おうん2", Janken.PAPER, 1, None)
+    opp_extra = Card("opp_extra", "opp_extra", "おっぷ", Janken.ROCK, 1, None)
+    opp_deck = Card("opp_deck", "opp_deck", "おっぷでっき", Janken.PAPER, 1, None)
+    state = GameState(
+        player=PlayerState(hand=[haruka], deck=[own_deck_1, own_deck_2]),
+        npc=PlayerState(hand=[emily, opp_extra], deck=[opp_deck]),
+    )
+
+    state = resolve_round(state, haruka, emily)
+
+    assert len(state.player.hand) == 2
+    assert state.npc.hand == [opp_extra]
+    assert state.npc.deck == [opp_deck]

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -556,6 +556,40 @@ def test_karen_choose_activate_sets_must_reveal_on_opponent():
     assert state.npc.must_reveal_played_card_rounds == 2
 
 
+def test_immune_blocks_karen_choose_reveal_effect_on_resume():
+    karen = Card(
+        "card_45",
+        "可憐",
+        "かれん",
+        Janken.SCISSORS,
+        11,
+        Effect(EffectType.CHOOSE, "choose", None),
+    )
+    emily = Card(
+        "card_32",
+        "エミリー",
+        "えみりー",
+        Janken.SCISSORS,
+        13,
+        Effect(EffectType.IMMUNE, "immune", None),
+    )
+    state = GameState(
+        player=PlayerState(hand=[karen]),
+        npc=PlayerState(hand=[emily]),
+    )
+
+    state = resolve_round(state, karen, emily)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+
+    state = resume_round_effect(state, choice="activate")
+
+    assert state.npc.must_reveal_played_card_rounds == 0
+    assert any(
+        "可憐の効果: 相手は戦具効果を受けないため不発" in log
+        for log in state.battle_log
+    )
+
+
 def test_umi_choose_multiple_discard_only_applies_buff():
     umi = Card(
         "card_29",


### PR DESCRIPTION
## 概要
- card_32 エミリーの `immune` 効果を実装
- 相手の戦具効果によるポイント変更、無効化、公開、強制プレイなどを防ぐ共通判定を追加
- 双方に作用するドロー効果では、自分側の処理は通常どおり進め、immune 側への影響だけを防止

## テスト
- `.venv/bin/python -m pytest`
- `ruff format`
- `ruff check --fix --extend-select I`
- `.venv/bin/python scripts/check_unimplemented_effects.py`
