### PR TITLE
feat(effects): implement conditional negate buff

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -832,8 +832,7 @@ def effect_conditional_negate_buff(
     state: GameState, side: Side, card: Card
 ) -> GameState:
     opp_side = get_opponent_side(side)
-    if _opponent_is_immune(state, side):
-        return _immune_blocked_state(state, card)
+    opponent_is_immune = _opponent_is_immune(state, side)
 
     current_battle = state.current_battle
     if current_battle is None:
@@ -865,8 +864,18 @@ def effect_conditional_negate_buff(
         )
 
     bonus = int(card.effect.value or 0)
-    state = update_player(state, opp_side, effect_negated=True)
+    if not opponent_is_immune:
+        state = update_player(state, opp_side, effect_negated=True)
     state = update_player(state, side, point_modifier=p_state.point_modifier + bonus)
+    if opponent_is_immune:
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [
+                f"{card.name}の効果発動: 相手のポイント({opponent_point})が奇数だが、相手は戦具効果を受けないため無効化できず、ポイント+{bonus}"
+            ],
+        )
+
     return replace(
         state,
         battle_log=state.battle_log

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -827,6 +827,55 @@ def effect_conditional_buff(state: GameState, side: Side, card: Card) -> GameSta
     )
 
 
+@register("conditional_negate_buff")
+def effect_conditional_negate_buff(
+    state: GameState, side: Side, card: Card
+) -> GameState:
+    opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
+    current_battle = state.current_battle
+    if current_battle is None:
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 場のカードがないため不発"],
+        )
+
+    p_state = get_player_state(state, side)
+    opp_state = get_player_state(state, opp_side)
+    opp_card = (
+        current_battle.npc_card if opp_side == Side.NPC else current_battle.player_card
+    )
+    conditional = (
+        opp_state.conditional_point_modifier_non_wildcard
+        if opp_card.janken != Janken.WILDCARD
+        else 0
+    )
+    opponent_point = opp_card.base_point + opp_state.point_modifier + conditional
+
+    if opponent_point % 2 == 0:
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [
+                f"{card.name}の効果発動: 相手のポイント({opponent_point})が偶数のため不発"
+            ],
+        )
+
+    bonus = int(card.effect.value or 0)
+    state = update_player(state, opp_side, effect_negated=True)
+    state = update_player(state, side, point_modifier=p_state.point_modifier + bonus)
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [
+            f"{card.name}の効果発動: 相手のポイント({opponent_point})が奇数のため相手の戦具効果を無効化し、ポイント+{bonus}"
+        ],
+    )
+
+
 @register("conditional_debuff_next")
 def effect_conditional_debuff_next(
     state: GameState, side: Side, card: Card

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1864,6 +1864,35 @@ def test_conditional_negate_buff_does_not_apply_when_opponent_point_is_even():
     assert any("相手のポイント(14)が偶数のため不発" in log for log in state.battle_log)
 
 
+def test_conditional_negate_buff_keeps_own_buff_against_immune_opponent():
+    nao = Card(
+        "card_37",
+        "奈緒",
+        "なお",
+        Janken.PAPER,
+        12,
+        Effect(EffectType.CONDITIONAL_NEGATE_BUFF, "conditional negate buff", 3),
+    )
+    emily = Card(
+        "card_32",
+        "エミリー",
+        "えみりー",
+        Janken.PAPER,
+        13,
+        Effect(EffectType.IMMUNE, "immune", None),
+    )
+    state = GameState(player=PlayerState(hand=[nao]), npc=PlayerState(hand=[emily]))
+
+    state = resolve_round(state, nao, emily)
+
+    assert state.phase == Phase.REVEAL
+    assert state.player.point_modifier == 3
+    assert state.npc.effect_negated is False
+    assert state.current_battle.player_point == 15
+    assert state.current_battle.npc_point == 13
+    assert any("戦具効果を受けないため無効化できず" in log for log in state.battle_log)
+
+
 def test_immune_blocks_opponent_set_point_compared_with_non_immune_card():
     azusa = Card(
         "card_10",

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1806,6 +1806,64 @@ def test_conditional_buff_does_not_apply_when_opponent_won_total_is_not_higher()
     assert any("不発" in log for log in state.battle_log)
 
 
+def test_conditional_negate_buff_applies_when_opponent_point_is_odd():
+    nao = Card(
+        "card_37",
+        "奈緒",
+        "なお",
+        Janken.PAPER,
+        12,
+        Effect(EffectType.CONDITIONAL_NEGATE_BUFF, "conditional negate buff", 3),
+    )
+    other = Card(
+        "cx",
+        "other",
+        "おざー",
+        Janken.PAPER,
+        13,
+        Effect(EffectType.BUFF, "+5", 5),
+    )
+    state = GameState(player=PlayerState(hand=[nao]), npc=PlayerState(hand=[other]))
+
+    state = resolve_round(state, nao, other)
+
+    assert state.phase == Phase.REVEAL
+    assert state.player.point_modifier == 3
+    assert state.npc.effect_negated is True
+    assert state.current_battle.player_point == 15
+    assert state.current_battle.npc_point == 13
+    assert any("相手のポイント(13)が奇数" in log for log in state.battle_log)
+
+
+def test_conditional_negate_buff_does_not_apply_when_opponent_point_is_even():
+    nao = Card(
+        "card_37",
+        "奈緒",
+        "なお",
+        Janken.PAPER,
+        12,
+        Effect(EffectType.CONDITIONAL_NEGATE_BUFF, "conditional negate buff", 3),
+    )
+    other = Card(
+        "cx",
+        "other",
+        "おざー",
+        Janken.PAPER,
+        14,
+        Effect(EffectType.BUFF, "+5", 5),
+    )
+    state = GameState(player=PlayerState(hand=[nao]), npc=PlayerState(hand=[other]))
+
+    state = resolve_round(state, nao, other)
+
+    assert state.phase == Phase.REVEAL
+    assert state.player.point_modifier == 0
+    assert state.npc.effect_negated is False
+    assert state.current_battle.player_point == 12
+    assert state.current_battle.npc_point == 19
+    assert any("相手のポイント(14)が偶数のため不発" in log for log in state.battle_log)
+
+
 def test_immune_blocks_opponent_set_point_compared_with_non_immune_card():
     azusa = Card(
         "card_10",


### PR DESCRIPTION
## 概要
- `conditional_negate_buff` の効果ハンドラを追加
- 相手場ポイントが奇数のときのみ、相手効果無効化と自分+3を同時に適用
- 奇数/偶数ケースの回帰テストを追加

## テスト
- `.venv/bin/python -m pytest tests/test_effects.py -k conditional_negate_buff`
- `ruff format`
- `ruff check --fix --extend-select I`
- `.venv/bin/python -m pytest`

Closes #39
