### PR TITLE
feat(effects): implement set_point_match

### DIFF
--- a/app.py
+++ b/app.py
@@ -466,6 +466,20 @@ def render_pending_effect_form(game_state):
             submit_effect_choice(game_state, choice)
         return
 
+    if ctx.effect == "set_point_match":
+        choice = st.radio(
+            "歩の効果",
+            ["activate", "skip"],
+            format_func=lambda value: {
+                "activate": "発動する",
+                "skip": "発動しない",
+            }[value],
+            horizontal=True,
+        )
+        if st.button("決定", type="primary", use_container_width=True):
+            submit_effect_choice(game_state, choice)
+        return
+
     if ctx.effect == "reorder":
         options, labels = card_id_options(player.deck)
         if len(options) <= 1:

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -19,6 +19,7 @@ from shadow_bout.models import (
     PendingEffectContext,
     PersistentPointEffect,
     Phase,
+    PointMatchEffect,
     Side,
 )
 
@@ -418,6 +419,34 @@ def _resume_removal(state: GameState, side: Side, choice: str | None) -> GameSta
     return _finish_interactive_effect(state, "-> ジュリアの効果: 勝敗判定をスキップ")
 
 
+def _resume_set_point_match(
+    state: GameState, side: Side, choice: str | None
+) -> GameState:
+    ctx = state.pending_effect_context
+    source_card = _find_card_by_id(state, side, ctx.card_id if ctx else None)
+    source_name = source_card.name if source_card else "歩"
+
+    if choice != "activate":
+        return _finish_interactive_effect(state, f"-> {source_name}の効果: 発動しない")
+
+    if _opponent_is_immune(state, side):
+        return _finish_interactive_effect(
+            state, f"-> {source_name}の効果: 相手は戦具効果を受けないため不発"
+        )
+
+    effect = PointMatchEffect(
+        source_side=side,
+        target_side=get_opponent_side(side),
+    )
+    state = replace(
+        state,
+        point_match_effects=state.point_match_effects + (effect,),
+    )
+    return _finish_interactive_effect(
+        state, f"-> {source_name}の効果: 相手のポイントをこのカードと同じにする"
+    )
+
+
 def resume_pending_effect(state: GameState, choice: str | None = None) -> GameState:
     ctx = state.pending_effect_context
     if not ctx:
@@ -436,6 +465,8 @@ def resume_pending_effect(state: GameState, choice: str | None = None) -> GameSt
         return _resume_swap_opponent(state, side, choice)
     if ctx.effect == "removal":
         return _resume_removal(state, side, choice)
+    if ctx.effect == "set_point_match":
+        return _resume_set_point_match(state, side, choice)
     if ctx.effect == "salvage":
         return _resume_salvage(state, side, choice)
     if ctx.effect == "reorder":
@@ -794,6 +825,18 @@ def effect_set_point(state: GameState, side: Side, card: Card) -> GameState:
     )
 
 
+@register("set_point_match")
+def effect_set_point_match(state: GameState, side: Side, card: Card) -> GameState:
+    ctx = PendingEffectContext(side=side, card_id=card.id, effect="set_point_match")
+    state = replace(
+        state, phase=Phase.INTERACTIVE_EFFECT, effect_step=0, pending_effect_context=ctx
+    )
+    return replace(
+        state,
+        battle_log=state.battle_log + [f"{card.name}の効果発動: 発動選択待機中..."],
+    )
+
+
 @register("conditional_buff")
 def effect_conditional_buff(state: GameState, side: Side, card: Card) -> GameState:
     p_state = get_player_state(state, side)
@@ -1138,6 +1181,7 @@ def effect_restart(state: GameState, side: Side, card: Card) -> GameState:
         effect_queue=[],
         last_restart_round=state.round_number,
         pending_conditional_debuff_on_loss=(),
+        point_match_effects=(),
     )
 
 

--- a/shadow_bout/effect_scoring.py
+++ b/shadow_bout/effect_scoring.py
@@ -33,6 +33,12 @@ def resolve_post_effect_points(state: GameState) -> GameState:
     p_point = calculate_effective_point(res.player_card, state.player)
     n_point = calculate_effective_point(res.npc_card, state.npc)
 
+    points = {Side.PLAYER: p_point, Side.NPC: n_point}
+    for effect in state.point_match_effects:
+        points[effect.target_side] = points[effect.source_side]
+    p_point = points[Side.PLAYER]
+    n_point = points[Side.NPC]
+
     if p_point > n_point:
         outcome = RoundOutcome.WIN
         winning_side = Side.PLAYER

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -202,6 +202,7 @@ def reset_round_state(game_state: GameState) -> GameState:
         revealed_this_round=None,
         revealed_this_round_side=None,
         pending_conditional_debuff_on_loss=(),
+        point_match_effects=(),
     )
 
 
@@ -700,6 +701,11 @@ def _choose_npc_pending_effect(
         return "swap"
 
     if ctx.effect == "removal":
+        if source_card and npc_strategy.should_activate(source_card, state):
+            return "activate"
+        return "skip"
+
+    if ctx.effect == "set_point_match":
         if source_card and npc_strategy.should_activate(source_card, state):
             return "activate"
         return "skip"

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -132,6 +132,12 @@ class PersistentPointEffect:
 
 
 @dataclass(frozen=True)
+class PointMatchEffect:
+    source_side: Side
+    target_side: Side
+
+
+@dataclass(frozen=True)
 class BattleResult:
     outcome: RoundOutcome  # WIN / LOSE / EVEN
     winning_side: Side | None  # EVEN の場合は None
@@ -167,3 +173,4 @@ class GameState:
     revealed_this_round: list[Card] | None = None
     revealed_this_round_side: Side | None = None
     pending_conditional_debuff_on_loss: tuple[tuple[Side, int], ...] = ()
+    point_match_effects: tuple[PointMatchEffect, ...] = ()

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1502,6 +1502,84 @@ def test_set_point_works_consistently_with_existing_point_modifier_order():
     assert state.current_battle.outcome == RoundOutcome.WIN
 
 
+def test_set_point_match_ayumu_matches_opponent_final_point_when_activated():
+    ayumu = Card(
+        "card_34",
+        "歩",
+        "あゆむ",
+        Janken.ROCK,
+        12,
+        Effect(EffectType.SET_POINT_MATCH, "set point match", None),
+    )
+    opponent = Card("op", "opponent", "おざー", Janken.ROCK, 18, None)
+    state = GameState(
+        player=PlayerState(hand=[ayumu]),
+        npc=PlayerState(hand=[opponent]),
+    )
+
+    state = resolve_round(state, ayumu, opponent)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+
+    state = resume_round_effect(state, choice="activate")
+
+    assert state.current_battle.player_point == 12
+    assert state.current_battle.npc_point == 12
+    assert state.current_battle.outcome == RoundOutcome.EVEN
+
+
+def test_set_point_match_ayumu_can_be_skipped():
+    ayumu = Card(
+        "card_34",
+        "歩",
+        "あゆむ",
+        Janken.ROCK,
+        12,
+        Effect(EffectType.SET_POINT_MATCH, "set point match", None),
+    )
+    opponent = Card("op", "opponent", "おざー", Janken.ROCK, 18, None)
+    state = GameState(
+        player=PlayerState(hand=[ayumu]),
+        npc=PlayerState(hand=[opponent]),
+    )
+
+    state = resolve_round(state, ayumu, opponent)
+    state = resume_round_effect(state, choice="skip")
+
+    assert state.current_battle.player_point == 12
+    assert state.current_battle.npc_point == 18
+    assert state.current_battle.outcome == RoundOutcome.LOSE
+
+
+def test_set_point_match_ayumu_matches_after_later_point_modifier():
+    ayumu = Card(
+        "card_34",
+        "歩",
+        "あゆむ",
+        Janken.ROCK,
+        12,
+        Effect(EffectType.SET_POINT_MATCH, "set point match", None),
+    )
+    takane = Card(
+        "c8",
+        "貴音",
+        "たかね",
+        Janken.ROCK,
+        14,
+        Effect(EffectType.BUFF, "+1", 1),
+    )
+    state = GameState(
+        player=PlayerState(hand=[ayumu]),
+        npc=PlayerState(hand=[takane]),
+    )
+
+    state = resolve_round(state, ayumu, takane)
+    state = resume_round_effect(state, choice="activate")
+
+    assert state.current_battle.player_point == 12
+    assert state.current_battle.npc_point == 12
+    assert state.current_battle.outcome == RoundOutcome.EVEN
+
+
 def test_debuff_persistent_applies_current_and_next_round_only():
     hinata = Card(
         "c35",


### PR DESCRIPTION
## 概要
- card_34（歩）の set_point_match 効果を実装
- 発動/不発の選択処理を Streamlit UI と NPC 自動解決に追加
- ポイント比較直前に相手最終ポイントをこのカード側の最終ポイントへ同値化

## テスト
- ruff format
- ruff check --fix --extend-select I
- .venv/bin/python -m pytest

Closes #45