### PR TITLE
feat(effects): implement debuff counterable

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,6 +30,7 @@ CARD_IDS = [
     "card_25",
     "card_15",
     "card_38",
+    "card_33",
     "card_02",
     "card_08",
     "card_06",
@@ -346,6 +347,37 @@ def render_pending_effect_form(game_state):
             use_container_width=True,
         ):
             submit_effect_choice(game_state, ",".join(selected))
+        return
+
+    if ctx.effect == "debuff_counterable":
+        if not player.hand:
+            st.info("捨てられる手札がないため無効化できません。")
+            if st.button("次へ", type="primary", use_container_width=True):
+                submit_effect_choice(game_state, "skip")
+            return
+
+        mode = st.radio(
+            "志保の効果",
+            ["counter", "skip"],
+            format_func=lambda value: {
+                "counter": "手札1枚を捨て札にして無効化する",
+                "skip": "無効化しない",
+            }[value],
+            horizontal=True,
+        )
+        if mode == "skip":
+            if st.button("無効化しない", type="primary", use_container_width=True):
+                submit_effect_choice(game_state, "skip")
+            return
+
+        options, labels = card_id_options(player.hand)
+        choice = st.selectbox(
+            "捨て札にする手札",
+            options,
+            format_func=lambda card_id: labels[card_id],
+        )
+        if st.button("無効化する", type="primary", use_container_width=True):
+            submit_effect_choice(game_state, choice)
         return
 
     if ctx.effect == "search_and_swap":

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -386,6 +386,49 @@ def _resume_choose_multiple(
     return _finish_interactive_effect(state, f"-> 海美の効果: {'、'.join(logs)}")
 
 
+def _resume_debuff_counterable(
+    state: GameState, side: Side, choice: str | None
+) -> GameState:
+    ctx = state.pending_effect_context
+    source_side = get_opponent_side(side)
+    source_card = _find_card_by_id(state, source_side, ctx.card_id if ctx else None)
+    source_name = source_card.name if source_card else "志保"
+    debuff = int(
+        source_card.effect.value
+        if source_card and source_card.effect
+        else (ctx.payload.get("debuff", -5) if ctx else -5)
+    )
+
+    p_state = get_player_state(state, side)
+    discard_target = None
+    if choice == "counter":
+        discard_target = p_state.hand[0] if p_state.hand else None
+    elif choice not in (None, "", "skip", "no_counter"):
+        discard_target = _find_card(p_state.hand, choice)
+
+    if discard_target is None:
+        state = update_player(
+            state,
+            side,
+            point_modifier=p_state.point_modifier + debuff,
+        )
+        return _finish_interactive_effect(
+            state,
+            f"-> {source_name}の効果: 相手が無効化せず、相手のポイント{debuff:+d}",
+        )
+
+    state = update_player(
+        state,
+        side,
+        hand=[card for card in p_state.hand if card.id != discard_target.id],
+        discard=p_state.discard + [discard_target],
+    )
+    return _finish_interactive_effect(
+        state,
+        f"-> {source_name}の効果: 相手は{discard_target.name}を捨札にして無効化",
+    )
+
+
 def _resume_removal(state: GameState, side: Side, choice: str | None) -> GameState:
     if choice not in (None, "activate", "yes", "true"):
         return _finish_interactive_effect(state, "-> ジュリアの効果: 発動しない")
@@ -473,6 +516,8 @@ def resume_pending_effect(state: GameState, choice: str | None = None) -> GameSt
         return _resume_reorder(state, side, choice)
     if ctx.effect == "choose_multiple":
         return _resume_choose_multiple(state, side, choice)
+    if ctx.effect == "debuff_counterable":
+        return _resume_debuff_counterable(state, side, choice)
 
     return _finish_interactive_effect(state, "-> 選択完了")
 
@@ -796,6 +841,42 @@ def effect_debuff(state: GameState, side: Side, card: Card) -> GameState:
         )
 
     return state
+
+
+@register("debuff_counterable")
+def effect_debuff_counterable(state: GameState, side: Side, card: Card) -> GameState:
+    opp_side = get_opponent_side(side)
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
+    debuff = int(card.effect.value or 0)
+    opp_state = get_player_state(state, opp_side)
+    if not opp_state.hand:
+        state = update_player(
+            state,
+            opp_side,
+            point_modifier=opp_state.point_modifier + debuff,
+        )
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 相手の手札がないため相手のポイント{debuff:+d}"],
+        )
+
+    ctx = PendingEffectContext(
+        side=opp_side,
+        card_id=card.id,
+        effect="debuff_counterable",
+        payload={"debuff": debuff},
+    )
+    state = replace(
+        state, phase=Phase.INTERACTIVE_EFFECT, effect_step=0, pending_effect_context=ctx
+    )
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手の無効化選択待機中..."],
+    )
 
 
 @register("set_point")

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -730,6 +730,16 @@ def _choose_npc_pending_effect(
             choices.append("draw_debuff")
         return ",".join(choices) if choices else None
 
+    if ctx.effect == "debuff_counterable":
+        if not npc.hand:
+            return "skip"
+        if (
+            source_card
+            and npc_strategy.choose_effect(["counter", "skip"], state) == "counter"
+        ):
+            return npc_strategy.select_target(npc.hand, state).id
+        return "skip"
+
     return None
 
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1450,6 +1450,86 @@ def test_debuff_kotoha_reduces_by_opponent_hand_count():
     assert state.current_battle.player_point == 13
 
 
+def test_debuff_counterable_applies_debuff_when_opponent_skips_counter():
+    shiho = Card(
+        "card_33",
+        "志保",
+        "しほ",
+        Janken.ROCK,
+        11,
+        Effect(EffectType.DEBUFF_COUNTERABLE, "counterable -5", -5),
+    )
+    opponent = Card("op", "opponent", "おざー", Janken.ROCK, 14, None)
+    extra = Card("n_extra", "n_extra", "ん", Janken.PAPER, 1, None)
+    state = GameState(
+        player=PlayerState(hand=[shiho]),
+        npc=PlayerState(hand=[opponent, extra]),
+    )
+
+    state = resolve_round(state, shiho, opponent)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+    assert state.pending_effect_context.side == Side.NPC
+
+    state = resume_round_effect(state, choice="skip")
+
+    assert state.phase == Phase.REVEAL
+    assert state.current_battle.player_point == 11
+    assert state.current_battle.npc_point == 9
+    assert state.current_battle.outcome == RoundOutcome.WIN
+    assert state.npc.hand == [extra]
+
+
+def test_debuff_counterable_discards_one_hand_card_and_negates_debuff():
+    shiho = Card(
+        "card_33",
+        "志保",
+        "しほ",
+        Janken.ROCK,
+        11,
+        Effect(EffectType.DEBUFF_COUNTERABLE, "counterable -5", -5),
+    )
+    opponent = Card("op", "opponent", "おざー", Janken.ROCK, 14, None)
+    extra = Card("n_extra", "n_extra", "ん", Janken.PAPER, 1, None)
+    state = GameState(
+        player=PlayerState(hand=[shiho]),
+        npc=PlayerState(hand=[opponent, extra]),
+    )
+
+    state = resolve_round(state, shiho, opponent)
+    state = resume_round_effect(state, choice=extra.id)
+
+    assert state.phase == Phase.REVEAL
+    assert state.current_battle.player_point == 11
+    assert state.current_battle.npc_point == 14
+    assert state.current_battle.outcome == RoundOutcome.LOSE
+    assert state.npc.hand == []
+    assert state.npc.discard == [extra, opponent]
+
+
+def test_debuff_counterable_applies_debuff_when_opponent_has_no_hand():
+    shiho = Card(
+        "card_33",
+        "志保",
+        "しほ",
+        Janken.ROCK,
+        11,
+        Effect(EffectType.DEBUFF_COUNTERABLE, "counterable -5", -5),
+    )
+    opponent = Card("op", "opponent", "おざー", Janken.ROCK, 14, None)
+    state = GameState(
+        player=PlayerState(hand=[shiho]),
+        npc=PlayerState(hand=[opponent]),
+    )
+
+    state = resolve_round(state, shiho, opponent)
+
+    assert state.phase == Phase.REVEAL
+    assert state.pending_effect_context is None
+    assert state.current_battle.player_point == 11
+    assert state.current_battle.npc_point == 9
+    assert state.current_battle.outcome == RoundOutcome.WIN
+
+
 def test_set_point_azusa_sets_opponent_point_to_zero():
     azusa = Card(
         "card_10",


### PR DESCRIPTION
## 概要
- `debuff_counterable` を登録し、志保の相手-5効果と手札discardによる無効化を実装
- 相手側の `INTERACTIVE_EFFECT` と NPC 自動選択、Streamlit UI の無効化選択を追加
- アプリの使用カード一覧に `card_33` を追加

## テスト
- `.venv/bin/python -m pytest`
- `ruff format`
- `ruff check --fix --extend-select I`
