### PR TITLE
feat(effects): implement tutor_play

### DIFF
--- a/app.py
+++ b/app.py
@@ -416,6 +416,43 @@ def render_pending_effect_form(game_state):
             submit_effect_choice(game_state, choice)
         return
 
+    if ctx.effect == "tutor_play":
+        mode = st.radio(
+            "麗花の効果",
+            ["activate", "skip"],
+            format_func=lambda value: {
+                "activate": "発動する",
+                "skip": "発動しない",
+            }[value],
+            horizontal=True,
+        )
+        if mode == "skip":
+            if st.button("発動しない", type="primary", use_container_width=True):
+                submit_effect_choice(game_state, "skip")
+            return
+
+        battle_card = None
+        if game_state.current_battle is not None:
+            battle_card = game_state.current_battle.player_card
+        candidates = list(player.deck)
+        if battle_card is not None:
+            candidates.append(battle_card)
+        options, labels = card_id_options(candidates)
+        if not options:
+            st.info("場に出せるカードがありません。")
+            if st.button("次へ", type="primary", use_container_width=True):
+                submit_effect_choice(game_state, "skip")
+            return
+
+        choice = st.selectbox(
+            "場に出すカード",
+            options,
+            format_func=lambda card_id: labels[card_id],
+        )
+        if st.button("場に出す", type="primary", use_container_width=True):
+            submit_effect_choice(game_state, choice)
+        return
+
     if ctx.effect == "swap_opponent":
         opponent = game_state.npc if ctx.side == Side.PLAYER else game_state.player
         if not opponent.hand:

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -231,6 +231,45 @@ def _resume_swap(state: GameState, side: Side, choice: str | None) -> GameState:
     )
 
 
+def _resume_tutor_play(state: GameState, side: Side, choice: str | None) -> GameState:
+    if choice in (None, "", "skip"):
+        return _finish_interactive_effect(state, "-> 麗花の効果: 発動しない")
+
+    p_state = get_player_state(state, side)
+    res = state.current_battle
+    if res is None:
+        return _finish_interactive_effect(
+            state, "-> 麗花の効果: 場のカードがないため不発"
+        )
+
+    old_card = res.player_card if side == Side.PLAYER else res.npc_card
+    target = _find_card(p_state.deck, choice)
+
+    if choice == old_card.id:
+        new_deck = list(p_state.deck)
+        random.shuffle(new_deck)
+        state = update_player(state, side, deck=new_deck)
+        return _finish_interactive_effect(
+            state, f"-> 麗花の効果: {old_card.name}を場に出し直し、山札を切った"
+        )
+
+    if target is None:
+        return _finish_interactive_effect(state, "-> 麗花の効果: 発動しない")
+
+    if side == Side.PLAYER:
+        new_res = replace(res, player_card=target)
+    else:
+        new_res = replace(res, npc_card=target)
+
+    new_deck = [card for card in p_state.deck if card.id != target.id] + [old_card]
+    random.shuffle(new_deck)
+    state = update_player(state, side, deck=new_deck)
+    state = replace(state, current_battle=new_res)
+    return _finish_interactive_effect(
+        state, f"-> 麗花の効果: {old_card.name}を山札に戻し、{target.name}を場に出した"
+    )
+
+
 def _resume_swap_opponent(
     state: GameState, side: Side, choice: str | None
 ) -> GameState:
@@ -432,6 +471,8 @@ def resume_pending_effect(state: GameState, choice: str | None = None) -> GameSt
         return _resume_search_and_swap(state, side, choice)
     if ctx.effect == "swap":
         return _resume_swap(state, side, choice)
+    if ctx.effect == "tutor_play":
+        return _resume_tutor_play(state, side, choice)
     if ctx.effect == "swap_opponent":
         return _resume_swap_opponent(state, side, choice)
     if ctx.effect == "removal":
@@ -1247,6 +1288,19 @@ def effect_swap(state: GameState, side: Side, card: Card) -> GameState:
     return replace(
         state,
         battle_log=state.battle_log + [f"{card.name}の効果発動: 入れ替え選択待機中..."],
+    )
+
+
+@register("tutor_play")
+def effect_tutor_play(state: GameState, side: Side, card: Card) -> GameState:
+    ctx = PendingEffectContext(side=side, card_id=card.id, effect="tutor_play")
+    state = replace(
+        state, phase=Phase.INTERACTIVE_EFFECT, effect_step=0, pending_effect_context=ctx
+    )
+    return replace(
+        state,
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 場に出すカード選択待機中..."],
     )
 
 

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -694,7 +694,10 @@ def _choose_npc_pending_effect(
     if ctx.effect == "tutor_play":
         if not source_card or not npc_strategy.should_activate(source_card, state):
             return "skip"
-        candidates = list(npc.deck) + [source_card]
+        battle_card = state.current_battle.npc_card if state.current_battle else None
+        candidates = list(npc.deck)
+        if battle_card is not None:
+            candidates.append(battle_card)
         return npc_strategy.select_target(candidates, state).id
 
     if ctx.effect == "swap_opponent":

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -691,6 +691,12 @@ def _choose_npc_pending_effect(
             return None
         return npc_strategy.select_target(npc.hand, state).id
 
+    if ctx.effect == "tutor_play":
+        if not source_card or not npc_strategy.should_activate(source_card, state):
+            return "skip"
+        candidates = list(npc.deck) + [source_card]
+        return npc_strategy.select_target(candidates, state).id
+
     if ctx.effect == "swap_opponent":
         player = get_player_state(state, Side.PLAYER)
         if not player.hand:

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -39,6 +39,11 @@ class FirstChoiceStrategy:
         return True
 
 
+class LastChoiceStrategy(FirstChoiceStrategy):
+    def select_target(self, candidates, game_state):
+        return candidates[-1]
+
+
 def test_basic_point_calculation():
     # 1. 基本ポイント計算
     c = Card("c1", "test", "test", Janken.ROCK, 15)
@@ -2162,3 +2167,40 @@ def test_resolve_npc_pending_effects_progresses_tutor_play():
     assert state.current_battle.npc_point == 30
     assert target not in state.npc.deck
     assert {card.id for card in state.npc.deck} == {"card_48", "remain"}
+
+
+def test_npc_copy_hand_tutor_play_self_candidate_uses_battle_card():
+    anna = Card(
+        "card_24",
+        "杏奈",
+        "あんな",
+        Janken.PAPER,
+        17,
+        Effect(EffectType.COPY_HAND, "copy hand", None),
+    )
+    reika = Card(
+        "card_48",
+        "麗花",
+        "れいか",
+        Janken.PAPER,
+        13,
+        Effect(EffectType.TUTOR_PLAY, "tutor play", None),
+    )
+    deck_card = Card("deck", "山札", "やまふだ", Janken.ROCK, 1, None)
+    other = Card("other", "相手札", "あいてふだ", Janken.PAPER, 20, None)
+    state = GameState(
+        player=PlayerState(hand=[other]),
+        npc=PlayerState(hand=[anna, reika], deck=[deck_card]),
+    )
+
+    random.seed(0)
+    state = resolve_round(state, other, anna)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+    assert state.pending_effect_context.effect == "copy_hand"
+
+    state = resolve_npc_pending_effects(state, LastChoiceStrategy())
+
+    assert state.phase == Phase.REVEAL
+    assert state.current_battle.npc_card == anna
+    assert state.npc.deck == [deck_card]
+    assert any("杏奈を場に出し直し" in log for log in state.battle_log)

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -2037,3 +2037,128 @@ def test_immune_blocks_only_opponent_side_of_mutual_draw_effect():
     assert len(state.player.hand) == 2
     assert state.npc.hand == [opp_extra]
     assert state.npc.deck == [opp_deck]
+
+
+def test_tutor_play_swaps_deck_card_into_battle_without_triggering_effect():
+    reika = Card(
+        "card_48",
+        "麗花",
+        "れいか",
+        Janken.PAPER,
+        13,
+        Effect(EffectType.TUTOR_PLAY, "tutor play", None),
+    )
+    target = Card(
+        "target",
+        "強化札",
+        "きょうかふだ",
+        Janken.ROCK,
+        30,
+        Effect(EffectType.BUFF, "buff", 99),
+    )
+    remain = Card("remain", "残り札", "のこりふだ", Janken.SCISSORS, 1, None)
+    other = Card("other", "相手札", "あいてふだ", Janken.PAPER, 20, None)
+    state = GameState(
+        player=PlayerState(hand=[reika], deck=[target, remain]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    random.seed(0)
+    state = resolve_round(state, reika, other)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+
+    state = resume_round_effect(state, choice=target.id)
+
+    assert state.phase == Phase.REVEAL
+    assert state.current_battle.player_card == target
+    assert state.current_battle.player_point == 30
+    assert state.player.point_modifier == 0
+    assert target not in state.player.deck
+    assert {card.id for card in state.player.deck} == {"card_48", "remain"}
+    assert target in state.player.discard
+    assert not any("強化札の効果発動" in log for log in state.battle_log)
+
+
+def test_tutor_play_skip_keeps_battle_card_and_deck_unchanged_by_effect():
+    reika = Card(
+        "card_48",
+        "麗花",
+        "れいか",
+        Janken.PAPER,
+        13,
+        Effect(EffectType.TUTOR_PLAY, "tutor play", None),
+    )
+    d1 = Card("d1", "山札1", "やまふだ1", Janken.ROCK, 1, None)
+    d2 = Card("d2", "山札2", "やまふだ2", Janken.SCISSORS, 2, None)
+    other = Card("other", "相手札", "あいてふだ", Janken.PAPER, 20, None)
+    state = GameState(
+        player=PlayerState(hand=[reika], deck=[d1, d2]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, reika, other)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+
+    state = resume_round_effect(state, choice="skip")
+
+    assert state.phase == Phase.REVEAL
+    assert state.current_battle.player_card == reika
+    assert state.player.deck == [d1, d2]
+    assert reika in state.npc.won_cards
+
+
+def test_tutor_play_can_select_self_when_deck_is_empty():
+    reika = Card(
+        "card_48",
+        "麗花",
+        "れいか",
+        Janken.PAPER,
+        13,
+        Effect(EffectType.TUTOR_PLAY, "tutor play", None),
+    )
+    other = Card("other", "相手札", "あいてふだ", Janken.PAPER, 20, None)
+    state = GameState(
+        player=PlayerState(hand=[reika], deck=[]),
+        npc=PlayerState(hand=[other]),
+    )
+
+    state = resolve_round(state, reika, other)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+
+    state = resume_round_effect(state, choice=reika.id)
+
+    assert state.phase == Phase.REVEAL
+    assert state.current_battle.player_card == reika
+    assert state.player.deck == []
+    assert reika in state.npc.won_cards
+
+
+def test_resolve_npc_pending_effects_progresses_tutor_play():
+    reika = Card(
+        "card_48",
+        "麗花",
+        "れいか",
+        Janken.PAPER,
+        13,
+        Effect(EffectType.TUTOR_PLAY, "tutor play", None),
+    )
+    target = Card("target", "強い札", "つよいふだ", Janken.ROCK, 30, None)
+    remain = Card("remain", "残り札", "のこりふだ", Janken.SCISSORS, 1, None)
+    other = Card("other", "相手札", "あいてふだ", Janken.PAPER, 20, None)
+    state = GameState(
+        player=PlayerState(hand=[other]),
+        npc=PlayerState(hand=[reika], deck=[target, remain]),
+    )
+
+    random.seed(0)
+    state = resolve_round(state, other, reika)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+    assert state.pending_effect_context.side == Side.NPC
+
+    state = resolve_npc_pending_effects(state, FirstChoiceStrategy())
+
+    assert state.phase == Phase.REVEAL
+    assert state.current_battle.npc_card == target
+    assert state.current_battle.npc_point == 30
+    assert target not in state.npc.deck
+    assert {card.id for card in state.npc.deck} == {"card_48", "remain"}


### PR DESCRIPTION
## 概要
- card_48 麗花の `tutor_play` 効果を実装
- プレイヤーUIとNPC自動解決で発動/skipと場カード差し替えに対応
- 差し替え後のカード効果を追加発動しない挙動をテストで確認

Closes #44

## テスト
- `uv run pytest`
- `.venv/bin/python -m pytest`
- `ruff format`
- `ruff check --fix --extend-select I`
