### PR TITLE
feat(effects): implement conditional debuff draw

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -1033,6 +1033,58 @@ def effect_conditional_debuff_next(
     )
 
 
+@register("conditional_debuff_draw")
+def effect_conditional_debuff_draw(
+    state: GameState, side: Side, card: Card
+) -> GameState:
+    opp_side = get_opponent_side(side)
+    current_battle = state.current_battle
+    if current_battle is None:
+        return replace(
+            state,
+            battle_log=state.battle_log
+            + [f"{card.name}の効果発動: 場のカードがないため不発"],
+        )
+
+    opp_state = get_player_state(state, opp_side)
+    opp_card = (
+        current_battle.npc_card if opp_side == Side.NPC else current_battle.player_card
+    )
+    conditional = (
+        opp_state.conditional_point_modifier_non_wildcard
+        if opp_card.janken != Janken.WILDCARD
+        else 0
+    )
+    opponent_point = opp_card.base_point + opp_state.point_modifier + conditional
+    debuff = int(card.effect.value or 0)
+    draw_count = 1
+    logs = [f"勝利時に{draw_count}枚ドローを予約"]
+
+    if opponent_point <= 15:
+        if _opponent_is_immune(state, side):
+            logs.append(
+                f"相手のポイント({opponent_point})は15以下だが、"
+                "相手は戦具効果を受けないためポイント減少は不発"
+            )
+        else:
+            state = update_player(
+                state,
+                opp_side,
+                point_modifier=opp_state.point_modifier + debuff,
+            )
+            logs.append(
+                f"相手のポイント({opponent_point})が15以下のため相手{debuff:+d}"
+            )
+    else:
+        logs.append(f"相手のポイント({opponent_point})が16以上のためポイント減少は不発")
+
+    return replace(
+        state,
+        pending_draw_on_win=state.pending_draw_on_win + ((side, draw_count),),
+        battle_log=state.battle_log + [f"{card.name}の効果発動: {'、'.join(logs)}"],
+    )
+
+
 @register("debuff_persistent")
 def effect_debuff_persistent(state: GameState, side: Side, card: Card) -> GameState:
     opp_side = get_opponent_side(side)
@@ -1262,6 +1314,7 @@ def effect_restart(state: GameState, side: Side, card: Card) -> GameState:
         effect_queue=[],
         last_restart_round=state.round_number,
         pending_conditional_debuff_on_loss=(),
+        pending_draw_on_win=(),
         point_match_effects=(),
     )
 

--- a/shadow_bout/effect_scoring.py
+++ b/shadow_bout/effect_scoring.py
@@ -107,4 +107,33 @@ def resolve_post_effect_points(state: GameState) -> GameState:
                 ],
             )
 
+    for side, draw_count in state.pending_draw_on_win:
+        if side != winning_side:
+            continue
+
+        if side == Side.PLAYER:
+            drawn = updated_state.player.deck[:draw_count]
+            updated_state = replace(
+                updated_state,
+                player=replace(
+                    updated_state.player,
+                    hand=updated_state.player.hand + drawn,
+                    deck=updated_state.player.deck[len(drawn) :],
+                ),
+                battle_log=updated_state.battle_log
+                + [f"効果発動: 勝利したため{len(drawn)}枚ドロー"],
+            )
+        else:
+            drawn = updated_state.npc.deck[:draw_count]
+            updated_state = replace(
+                updated_state,
+                npc=replace(
+                    updated_state.npc,
+                    hand=updated_state.npc.hand + drawn,
+                    deck=updated_state.npc.deck[len(drawn) :],
+                ),
+                battle_log=updated_state.battle_log
+                + [f"効果発動: 勝利したため{len(drawn)}枚ドロー"],
+            )
+
     return updated_state

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -202,6 +202,7 @@ def reset_round_state(game_state: GameState) -> GameState:
         revealed_this_round=None,
         revealed_this_round_side=None,
         pending_conditional_debuff_on_loss=(),
+        pending_draw_on_win=(),
         point_match_effects=(),
     )
 

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -173,4 +173,5 @@ class GameState:
     revealed_this_round: list[Card] | None = None
     revealed_this_round_side: Side | None = None
     pending_conditional_debuff_on_loss: tuple[tuple[Side, int], ...] = ()
+    pending_draw_on_win: tuple[tuple[Side, int], ...] = ()
     point_match_effects: tuple[PointMatchEffect, ...] = ()

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1749,6 +1749,77 @@ def test_debuff_conditional_elena_does_not_apply_when_negated():
     assert state.npc.next_round_conditional_point_modifier_non_wildcard == 0
 
 
+def test_conditional_debuff_draw_applies_debuff_and_draws_when_won():
+    miya = Card(
+        "card_42",
+        "美也",
+        "みや",
+        Janken.PAPER,
+        12,
+        Effect(EffectType.CONDITIONAL_DEBUFF_DRAW, "conditional -5 then draw", -5),
+    )
+    opponent = Card("n1", "相手", "あいて", Janken.PAPER, 15, None)
+    draw_card = Card("d1", "山札", "やまふだ", Janken.ROCK, 3, None)
+    state = GameState(
+        player=PlayerState(hand=[miya], deck=[draw_card]),
+        npc=PlayerState(hand=[opponent]),
+    )
+
+    state = resolve_round(state, miya, opponent)
+
+    assert state.current_battle.outcome == RoundOutcome.WIN
+    assert state.current_battle.npc_point == 10
+    assert state.player.hand == [draw_card]
+    assert state.player.deck == []
+
+
+def test_conditional_debuff_draw_skips_debuff_when_opponent_point_is_high():
+    miya = Card(
+        "card_42",
+        "美也",
+        "みや",
+        Janken.PAPER,
+        12,
+        Effect(EffectType.CONDITIONAL_DEBUFF_DRAW, "conditional -5 then draw", -5),
+    )
+    opponent = Card("n1", "相手", "あいて", Janken.PAPER, 16, None)
+    draw_card = Card("d1", "山札", "やまふだ", Janken.ROCK, 3, None)
+    state = GameState(
+        player=PlayerState(hand=[miya], deck=[draw_card], point_modifier=5),
+        npc=PlayerState(hand=[opponent]),
+    )
+
+    state = resolve_round(state, miya, opponent)
+
+    assert state.current_battle.outcome == RoundOutcome.WIN
+    assert state.current_battle.npc_point == 16
+    assert state.player.hand == [draw_card]
+
+
+def test_conditional_debuff_draw_does_not_draw_when_not_won():
+    miya = Card(
+        "card_42",
+        "美也",
+        "みや",
+        Janken.PAPER,
+        12,
+        Effect(EffectType.CONDITIONAL_DEBUFF_DRAW, "conditional -5 then draw", -5),
+    )
+    opponent = Card("n1", "相手", "あいて", Janken.PAPER, 15, None)
+    draw_card = Card("d1", "山札", "やまふだ", Janken.ROCK, 3, None)
+    state = GameState(
+        player=PlayerState(hand=[miya], deck=[draw_card], point_modifier=-3),
+        npc=PlayerState(hand=[opponent]),
+    )
+
+    state = resolve_round(state, miya, opponent)
+
+    assert state.current_battle.outcome == RoundOutcome.LOSE
+    assert state.current_battle.npc_point == 10
+    assert state.player.hand == []
+    assert state.player.deck == [draw_card]
+
+
 def test_debuff_conditional_iku_applies_from_round_3():
     iku = Card(
         "card_30",


### PR DESCRIPTION
## 概要
- `conditional_debuff_draw` の効果ハンドラを追加
- 相手場ポイントが15以下のときだけ相手ポイント-5を適用
- ラウンド結果確定後、効果使用側が勝利した場合だけ1枚ドローする遅延処理を追加

## テスト
- `uv run pytest`
- `ruff format`
- `ruff check --fix --extend-select I`

Closes #47
