### PR TITLE
feat(effects): implement buff snowball

### DIFF
--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -1378,6 +1378,7 @@ def effect_restart(state: GameState, side: Side, card: Card) -> GameState:
         last_restart_round=state.round_number,
         pending_conditional_debuff_on_loss=(),
         pending_draw_on_win=(),
+        pending_next_round_buff_on_win=(),
         point_match_effects=(),
     )
 

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -828,6 +828,28 @@ def effect_buff_next(state: GameState, side: Side, card: Card) -> GameState:
     )
 
 
+@register("buff_snowball")
+def effect_buff_snowball(state: GameState, side: Side, card: Card) -> GameState:
+    p_state = get_player_state(state, side)
+    bonus = int(card.effect.value or 0)
+    state = update_player(
+        state,
+        side,
+        point_modifier=p_state.point_modifier + bonus,
+    )
+    return replace(
+        state,
+        pending_next_round_buff_on_win=(
+            state.pending_next_round_buff_on_win + ((side, bonus),)
+        ),
+        battle_log=state.battle_log
+        + [
+            f"{card.name}の効果発動: この勝負のポイント{bonus:+d}、"
+            f"勝利時に次ラウンドのポイント{bonus:+d}"
+        ],
+    )
+
+
 @register("buff_scaling")
 def effect_buff_scaling(state: GameState, side: Side, card: Card) -> GameState:
     p_state = get_player_state(state, side)

--- a/shadow_bout/effect_scoring.py
+++ b/shadow_bout/effect_scoring.py
@@ -136,4 +136,33 @@ def resolve_post_effect_points(state: GameState) -> GameState:
                 + [f"効果発動: 勝利したため{len(drawn)}枚ドロー"],
             )
 
+    for side, bonus in state.pending_next_round_buff_on_win:
+        if side != winning_side:
+            continue
+
+        if side == Side.PLAYER:
+            updated_state = replace(
+                updated_state,
+                player=replace(
+                    updated_state.player,
+                    next_round_point_modifier=(
+                        updated_state.player.next_round_point_modifier + bonus
+                    ),
+                ),
+                battle_log=updated_state.battle_log
+                + [f"効果発動: 勝利したため次ラウンドのポイント{bonus:+d}"],
+            )
+        else:
+            updated_state = replace(
+                updated_state,
+                npc=replace(
+                    updated_state.npc,
+                    next_round_point_modifier=(
+                        updated_state.npc.next_round_point_modifier + bonus
+                    ),
+                ),
+                battle_log=updated_state.battle_log
+                + [f"効果発動: 勝利したため次ラウンドのポイント{bonus:+d}"],
+            )
+
     return updated_state

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -203,6 +203,7 @@ def reset_round_state(game_state: GameState) -> GameState:
         revealed_this_round_side=None,
         pending_conditional_debuff_on_loss=(),
         pending_draw_on_win=(),
+        pending_next_round_buff_on_win=(),
         point_match_effects=(),
     )
 

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -174,4 +174,5 @@ class GameState:
     revealed_this_round_side: Side | None = None
     pending_conditional_debuff_on_loss: tuple[tuple[Side, int], ...] = ()
     pending_draw_on_win: tuple[tuple[Side, int], ...] = ()
+    pending_next_round_buff_on_win: tuple[tuple[Side, int], ...] = ()
     point_match_effects: tuple[PointMatchEffect, ...] = ()

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1326,6 +1326,65 @@ def test_buff_next_is_applied_only_on_next_round_for_player_side():
     assert third_state.player.point_modifier == 0
 
 
+def test_buff_snowball_applies_current_and_next_round_when_won():
+    konomi = Card(
+        "card_39",
+        "このみ",
+        "このみ",
+        Janken.PAPER,
+        14,
+        Effect(EffectType.BUFF_SNOWBALL, "this +3 and win next +3", 3),
+    )
+    opponent = Card("n1", "相手", "あいて", Janken.PAPER, 16, None)
+    next_player = Card("p2", "p2", "ぴー2", Janken.ROCK, 5, None)
+    next_npc = Card("n2", "n2", "えぬ2", Janken.SCISSORS, 5, None)
+    state = GameState(
+        player=PlayerState(hand=[konomi, next_player]),
+        npc=PlayerState(hand=[opponent, next_npc]),
+    )
+
+    state = resolve_round(state, konomi, opponent)
+
+    assert state.player.point_modifier == 3
+    assert state.current_battle.player_point == 17
+    assert state.current_battle.outcome == RoundOutcome.WIN
+    assert state.player.next_round_point_modifier == 3
+
+    next_state = proceed_to_next(state)
+    assert next_state.round_number == 2
+    assert next_state.player.point_modifier == 3
+    assert next_state.player.next_round_point_modifier == 0
+
+
+def test_buff_snowball_applies_current_round_only_when_not_won():
+    konomi = Card(
+        "card_39",
+        "このみ",
+        "このみ",
+        Janken.PAPER,
+        14,
+        Effect(EffectType.BUFF_SNOWBALL, "this +3 and win next +3", 3),
+    )
+    opponent = Card("n1", "相手", "あいて", Janken.PAPER, 18, None)
+    next_player = Card("p2", "p2", "ぴー2", Janken.ROCK, 5, None)
+    next_npc = Card("n2", "n2", "えぬ2", Janken.SCISSORS, 5, None)
+    state = GameState(
+        player=PlayerState(hand=[konomi, next_player]),
+        npc=PlayerState(hand=[opponent, next_npc]),
+    )
+
+    state = resolve_round(state, konomi, opponent)
+
+    assert state.player.point_modifier == 3
+    assert state.current_battle.player_point == 17
+    assert state.current_battle.outcome == RoundOutcome.LOSE
+    assert state.player.next_round_point_modifier == 0
+
+    next_state = proceed_to_next(state)
+    assert next_state.round_number == 2
+    assert next_state.player.point_modifier == 0
+
+
 def test_conditional_debuff_next_is_applied_only_on_next_round_for_npc_side():
     subaru = Card(
         "c47",

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -787,6 +787,34 @@ def test_ami_restart_clears_pending_conditional_debuff_on_loss():
     assert state.pending_conditional_debuff_on_loss == ()
 
 
+def test_ami_restart_clears_pending_snowball_buff_on_win():
+    snowball = Card(
+        "snowball",
+        "このみ効果",
+        "このみこうか",
+        Janken.SCISSORS,
+        10,
+        Effect(EffectType.BUFF_SNOWBALL, "this +3 and win next +3", 3),
+    )
+    ami = Card(
+        "c11",
+        "亜美",
+        "あみ",
+        Janken.SCISSORS,
+        12,
+        Effect(EffectType.RESTART, "restart", None),
+    )
+    state = GameState(
+        player=PlayerState(hand=[snowball]),
+        npc=PlayerState(hand=[ami]),
+    )
+
+    state = resolve_round(state, snowball, ami)
+
+    assert state.phase == Phase.SELECT
+    assert state.pending_next_round_buff_on_win == ()
+
+
 def test_ami_consecutive_restart():
     # 5. 亜美の連続使用不可
     ami = Card(


### PR DESCRIPTION
## 概要
- `buff_snowball` を登録し、この勝負の即時 +3 と勝利時の次ラウンド +3 を分離して実装
- 勝利時だけ次ラウンド加点へ変換する予約状態を追加
- 勝利時・敗北時の次ラウンド挙動をテストで追加

## テスト
- `uv run pytest tests/test_effects.py -k snowball`
- `uv run pytest`
- `ruff format`
- `ruff check --fix --extend-select I`
