### PR TITLE
feat(effects): implement card 03 special

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,6 +31,7 @@ CARD_IDS = [
     "card_15",
     "card_38",
     "card_33",
+    "card_03",
     "card_02",
     "card_08",
     "card_06",
@@ -388,6 +389,39 @@ def render_pending_effect_form(game_state):
             format_func=lambda card_id: labels[card_id],
         )
         if st.button("無効化する", type="primary", use_container_width=True):
+            submit_effect_choice(game_state, choice)
+        return
+
+    if ctx.effect == "special":
+        opponent = game_state.npc if ctx.side == Side.PLAYER else game_state.player
+        if ctx.step == 0:
+            label = st.radio(
+                "美希の効果",
+                list(WILDCARD_JANKEN_OPTIONS),
+                horizontal=True,
+            )
+            if st.button("宣言する", type="primary", use_container_width=True):
+                submit_effect_choice(game_state, WILDCARD_JANKEN_OPTIONS[label].value)
+            return
+
+        target_id = ctx.payload.get("revealed_card_id")
+        revealed = find_card_by_id(opponent.hand, target_id)
+        if revealed is not None:
+            st.write(f"確認したカード: **{render_card_info(revealed)}**")
+
+        options, labels = card_id_options(opponent.won_cards)
+        if not options:
+            st.info("相手の勝ち札がありません。")
+            if st.button("次へ", type="primary", use_container_width=True):
+                submit_effect_choice(game_state, None)
+            return
+
+        choice = st.selectbox(
+            "奪取する勝ち札",
+            options,
+            format_func=lambda card_id: labels[card_id],
+        )
+        if st.button("奪取する", type="primary", use_container_width=True):
             submit_effect_choice(game_state, choice)
         return
 

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -83,6 +83,17 @@ def _find_card_by_id(state: GameState, side: Side, card_id: str | None) -> Card 
     )
 
 
+def _remove_first_card_by_id(cards: list[Card], card_id: str) -> list[Card]:
+    removed = False
+    remaining: list[Card] = []
+    for card in cards:
+        if not removed and card.id == card_id:
+            removed = True
+            continue
+        remaining.append(card)
+    return remaining
+
+
 def _parse_card_ids(choice: str | None) -> list[str]:
     if not choice:
         return []
@@ -509,7 +520,7 @@ def _resume_special(state: GameState, side: Side, choice: str | None) -> GameSta
         state = update_player(
             state,
             opp_side,
-            won_cards=[card for card in opp_state.won_cards if card.id != target.id],
+            won_cards=_remove_first_card_by_id(opp_state.won_cards, target.id),
         )
         return _finish_interactive_effect(
             state,

--- a/shadow_bout/effect_handlers.py
+++ b/shadow_bout/effect_handlers.py
@@ -476,6 +476,85 @@ def _resume_debuff_counterable(
     )
 
 
+def _coerce_declared_janken(choice: str | None) -> Janken:
+    if choice is None:
+        return Janken.ROCK
+    try:
+        janken = Janken(choice)
+    except ValueError:
+        return Janken.ROCK
+    if janken not in (Janken.ROCK, Janken.SCISSORS, Janken.PAPER):
+        return Janken.ROCK
+    return janken
+
+
+def _resume_special(state: GameState, side: Side, choice: str | None) -> GameState:
+    ctx = state.pending_effect_context
+    source_card = _find_card_by_id(state, side, ctx.card_id if ctx else None)
+    source_name = source_card.name if source_card else "美希"
+    opp_side = get_opponent_side(side)
+    opp_state = get_player_state(state, opp_side)
+
+    if ctx and ctx.step == 1:
+        target = _find_card(opp_state.won_cards, choice) or (
+            opp_state.won_cards[0] if opp_state.won_cards else None
+        )
+        if target is None:
+            return _finish_interactive_effect(
+                state, f"-> {source_name}の効果: 相手の勝ち札がないため奪取できない"
+            )
+
+        own_state = get_player_state(state, side)
+        state = update_player(state, side, deck=own_state.deck + [target])
+        state = update_player(
+            state,
+            opp_side,
+            won_cards=[card for card in opp_state.won_cards if card.id != target.id],
+        )
+        return _finish_interactive_effect(
+            state,
+            f"-> {source_name}の効果: {target.name}を相手の勝ち札から奪い、自分の山札の下へ置いた",
+        )
+
+    declared = _coerce_declared_janken(choice)
+    declared_name = JANKEN_NAMES[declared]
+    if not opp_state.hand:
+        return _finish_interactive_effect(
+            state,
+            f"-> {source_name}の効果: {declared_name}を宣言したが、相手の手札がないため確認できない",
+        )
+
+    revealed = random.choice(opp_state.hand)
+    revealed_name = JANKEN_NAMES.get(revealed.janken, revealed.janken.value)
+    log = (
+        f"-> {source_name}の効果: {declared_name}を宣言し、"
+        f"相手手札から{revealed.name}({revealed_name})を確認"
+    )
+    if revealed.janken != declared:
+        return _finish_interactive_effect(state, f"{log}。一致しないため奪取なし")
+
+    if not opp_state.won_cards:
+        return _finish_interactive_effect(
+            state, f"{log}。一致したが相手の勝ち札がないため奪取できない"
+        )
+
+    next_ctx = replace(
+        ctx,
+        step=1,
+        payload={
+            **(ctx.payload if ctx else {}),
+            "declared_janken": declared.value,
+            "revealed_card_id": revealed.id,
+        },
+    )
+    return replace(
+        state,
+        phase=Phase.INTERACTIVE_EFFECT,
+        pending_effect_context=next_ctx,
+        battle_log=state.battle_log + [f"{log}。奪取する勝ち札を選択中..."],
+    )
+
+
 def _resume_removal(state: GameState, side: Side, choice: str | None) -> GameState:
     if choice not in (None, "activate", "yes", "true"):
         return _finish_interactive_effect(state, "-> ジュリアの効果: 発動しない")
@@ -567,6 +646,8 @@ def resume_pending_effect(state: GameState, choice: str | None = None) -> GameSt
         return _resume_choose_multiple(state, side, choice)
     if ctx.effect == "debuff_counterable":
         return _resume_debuff_counterable(state, side, choice)
+    if ctx.effect == "special":
+        return _resume_special(state, side, choice)
 
     return _finish_interactive_effect(state, "-> 選択完了")
 
@@ -804,6 +885,21 @@ def effect_steal_hand(state: GameState, side: Side, card: Card) -> GameState:
         state,
         battle_log=state.battle_log
         + [f"{card.name}の効果発動: 相手の手札から{stolen.name}を奪って手札に加えた"],
+    )
+
+
+@register("special")
+def effect_special(state: GameState, side: Side, card: Card) -> GameState:
+    if _opponent_is_immune(state, side):
+        return _immune_blocked_state(state, card)
+
+    ctx = PendingEffectContext(side=side, card_id=card.id, effect="special")
+    state = replace(
+        state, phase=Phase.INTERACTIVE_EFFECT, effect_step=0, pending_effect_context=ctx
+    )
+    return replace(
+        state,
+        battle_log=state.battle_log + [f"{card.name}の効果発動: 宣言待機中..."],
     )
 
 

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -3,6 +3,7 @@ from dataclasses import replace
 
 from shadow_bout.effect_utils import (
     get_effective_janken,
+    get_opponent_side,
     get_player_state,
     set_battle_janken_override,
 )
@@ -887,6 +888,16 @@ def _choose_npc_pending_effect(
         ):
             return npc_strategy.select_target(npc.hand, state).id
         return "skip"
+
+    if ctx.effect == "special":
+        if ctx.step == 0:
+            return npc_strategy.choose_effect(
+                [janken.value for janken in WILDCARD_DECLARABLE_JANKENS], state
+            )
+        opponent = get_player_state(state, get_opponent_side(ctx.side))
+        if not opponent.won_cards:
+            return None
+        return npc_strategy.select_target(opponent.won_cards, state).id
 
     return None
 

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1249,6 +1249,120 @@ def test_steal_hand_effect_noops_when_opponent_hand_is_empty():
     assert state.npc.hand == []
 
 
+def test_special_steals_opponent_won_card_when_declared_mark_matches_revealed_hand():
+    miki = Card(
+        "card_03",
+        "美希",
+        "みき",
+        Janken.ROCK,
+        16,
+        Effect(EffectType.SPECIAL, "special", None),
+    )
+    opponent = Card("op", "相手", "あいて", Janken.ROCK, 16, None)
+    revealed = Card("n_hand", "相手手札", "あいててふだ", Janken.PAPER, 1, None)
+    own_deck = Card("p_deck", "自分山札", "じぶんやまふだ", Janken.ROCK, 1, None)
+    won_keep = Card("n_won1", "相手勝ち札1", "あいてかちふだ1", Janken.ROCK, 2, None)
+    won_steal = Card(
+        "n_won2", "相手勝ち札2", "あいてかちふだ2", Janken.SCISSORS, 3, None
+    )
+    state = GameState(
+        player=PlayerState(hand=[miki], deck=[own_deck]),
+        npc=PlayerState(hand=[opponent, revealed], won_cards=[won_keep, won_steal]),
+    )
+
+    state = resolve_round(state, miki, opponent)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+
+    state = resume_round_effect(state, choice=Janken.PAPER.value)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+    assert state.pending_effect_context.effect == "special"
+    assert state.pending_effect_context.step == 1
+
+    state = resume_round_effect(state, choice=won_steal.id)
+
+    assert state.phase == Phase.REVEAL
+    assert state.player.deck == [own_deck, won_steal]
+    assert state.npc.won_cards == [won_keep]
+
+
+def test_special_does_not_steal_when_declared_mark_mismatches_revealed_hand():
+    miki = Card(
+        "card_03",
+        "美希",
+        "みき",
+        Janken.ROCK,
+        16,
+        Effect(EffectType.SPECIAL, "special", None),
+    )
+    opponent = Card("op", "相手", "あいて", Janken.ROCK, 16, None)
+    revealed = Card("n_hand", "相手手札", "あいててふだ", Janken.SCISSORS, 1, None)
+    won = Card("n_won", "相手勝ち札", "あいてかちふだ", Janken.ROCK, 2, None)
+    state = GameState(
+        player=PlayerState(hand=[miki]),
+        npc=PlayerState(hand=[opponent, revealed], won_cards=[won]),
+    )
+
+    state = resolve_round(state, miki, opponent)
+    state = resume_round_effect(state, choice=Janken.PAPER.value)
+
+    assert state.phase == Phase.REVEAL
+    assert state.player.deck == []
+    assert state.npc.won_cards == [won]
+    assert any("一致しないため奪取なし" in log for log in state.battle_log)
+
+
+def test_special_does_not_steal_when_opponent_has_no_won_cards():
+    miki = Card(
+        "card_03",
+        "美希",
+        "みき",
+        Janken.ROCK,
+        16,
+        Effect(EffectType.SPECIAL, "special", None),
+    )
+    opponent = Card("op", "相手", "あいて", Janken.ROCK, 16, None)
+    revealed = Card("n_hand", "相手手札", "あいててふだ", Janken.PAPER, 1, None)
+    state = GameState(
+        player=PlayerState(hand=[miki]),
+        npc=PlayerState(hand=[opponent, revealed], won_cards=[]),
+    )
+
+    state = resolve_round(state, miki, opponent)
+    state = resume_round_effect(state, choice=Janken.PAPER.value)
+
+    assert state.phase == Phase.REVEAL
+    assert state.player.deck == []
+    assert state.npc.won_cards == []
+    assert any("相手の勝ち札がないため奪取できない" in log for log in state.battle_log)
+
+
+def test_npc_special_declares_and_steals_with_strategy():
+    miki = Card(
+        "card_03",
+        "美希",
+        "みき",
+        Janken.ROCK,
+        16,
+        Effect(EffectType.SPECIAL, "special", None),
+    )
+    player_card = Card("op", "相手", "あいて", Janken.ROCK, 16, None)
+    player_hand = Card("p_hand", "プレイヤー手札", "ぷれいやーてふだ", Janken.ROCK, 1)
+    player_won = Card(
+        "p_won", "プレイヤー勝ち札", "ぷれいやーかちふだ", Janken.PAPER, 2
+    )
+    state = GameState(
+        player=PlayerState(hand=[player_card, player_hand], won_cards=[player_won]),
+        npc=PlayerState(hand=[miki]),
+    )
+
+    state = resolve_round(state, player_card, miki)
+    state = resolve_npc_pending_effects(state, FirstChoiceStrategy())
+
+    assert state.phase == Phase.REVEAL
+    assert state.player.won_cards == []
+    assert state.npc.deck == [player_won]
+
+
 def test_swap_opponent_effect_swaps_with_random_opponent_hand_card():
     random.seed(0)
     kana = Card(

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1285,6 +1285,32 @@ def test_special_steals_opponent_won_card_when_declared_mark_matches_revealed_ha
     assert state.npc.won_cards == [won_keep]
 
 
+def test_special_steals_only_one_won_card_when_same_id_exists():
+    miki = Card(
+        "card_03",
+        "美希",
+        "みき",
+        Janken.ROCK,
+        16,
+        Effect(EffectType.SPECIAL, "special", None),
+    )
+    opponent = Card("op", "相手", "あいて", Janken.ROCK, 16, None)
+    revealed = Card("n_hand", "相手手札", "あいててふだ", Janken.PAPER, 1, None)
+    won_a = Card("same_won", "相手勝ち札A", "あいてかちふだA", Janken.ROCK, 2, None)
+    won_b = Card("same_won", "相手勝ち札B", "あいてかちふだB", Janken.SCISSORS, 3, None)
+    state = GameState(
+        player=PlayerState(hand=[miki]),
+        npc=PlayerState(hand=[opponent, revealed], won_cards=[won_a, won_b]),
+    )
+
+    state = resolve_round(state, miki, opponent)
+    state = resume_round_effect(state, choice=Janken.PAPER.value)
+    state = resume_round_effect(state, choice=won_a.id)
+
+    assert state.player.deck == [won_a]
+    assert state.npc.won_cards == [won_b]
+
+
 def test_special_does_not_steal_when_declared_mark_mismatches_revealed_hand():
     miki = Card(
         "card_03",


### PR DESCRIPTION
## 概要
- card_03 美希の `special` 効果を実装
- 宣言、相手手札のランダム確認、一致時の相手勝ち札奪取を `INTERACTIVE_EFFECT` で段階処理
- NPC の自動宣言・奪取対象選択と Streamlit UI の入力フォームを追加
- アプリの使用デッキに card_03 を追加

## テスト
- `ruff format`
- `ruff check --fix --extend-select I`
- `.venv/bin/python -m pytest`

Closes #52
