### PR TITLE
feat(ui): add random 13-deck mode to start screen

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,7 @@ from shadow_bout import (
     resolve_npc_pending_effects_stepwise,
     resume_round_effect_stepwise,
     select_card_stepwise,
+    select_random_deck,
     start_game,
 )
 from shadow_bout.effects import calculate_effective_point
@@ -30,13 +31,10 @@ CARD_IDS = [
     "card_25",
     "card_15",
     "card_38",
-    "card_33",
-    "card_03",
     "card_02",
     "card_08",
     "card_06",
     "card_44",
-    "card_49",
     "card_50",
     "card_05",
 ]
@@ -654,11 +652,46 @@ def main():
     with col1:
         if game_state.phase == Phase.START:
             st.write("NPCとの陰界戦戯を開始します！")
+            st.markdown(
+                """
+                <style>
+                .st-key-engage_random button {
+                    background-color: #2563eb;
+                    color: #ffffff;
+                    border: 1px solid #1d4ed8;
+                }
+                .st-key-engage_random button:hover {
+                    background-color: #1d4ed8;
+                    color: #ffffff;
+                    border: 1px solid #1e3a8a;
+                }
+                </style>
+                """,
+                unsafe_allow_html=True,
+            )
             if st.button(
-                "シャドウバウト・エンゲージ", type="primary", use_container_width=True
+                "シャドウバウト・エンゲージ（固定13枚）",
+                type="primary",
+                use_container_width=True,
+                key="engage_fixed",
             ):
                 clear_reorder_widget_state()
+                st.session_state.game_mode = "fixed"
                 st.session_state.game_state = start_game(st.session_state.deck)
+                st.session_state.selected_card_id = None
+                st.rerun()
+            if st.button(
+                "シャドウバウト・エンゲージ（ランダム13枚）",
+                use_container_width=True,
+                key="engage_random",
+            ):
+                clear_reorder_widget_state()
+                p_deck = select_random_deck(13)
+                n_deck = select_random_deck(13)
+                st.session_state.game_mode = "random"
+                st.session_state.player_deck = p_deck
+                st.session_state.npc_deck = n_deck
+                st.session_state.game_state = start_game(p_deck, n_deck)
                 st.session_state.selected_card_id = None
                 st.rerun()
 
@@ -867,7 +900,13 @@ def main():
 
             if st.button("もう一度遊ぶ", use_container_width=True):
                 clear_reorder_widget_state()
-                st.session_state.game_state = start_game(st.session_state.deck)
+                if st.session_state.get("game_mode") == "random":
+                    st.session_state.game_state = start_game(
+                        st.session_state.player_deck,
+                        st.session_state.npc_deck,
+                    )
+                else:
+                    st.session_state.game_state = start_game(st.session_state.deck)
                 st.session_state.selected_card_id = None
                 st.rerun()
 

--- a/shadow_bout/__init__.py
+++ b/shadow_bout/__init__.py
@@ -1,4 +1,4 @@
-from shadow_bout.cards import load_deck
+from shadow_bout.cards import load_deck, select_random_deck
 from shadow_bout.engine import (
     calculate_final_score,
     continue_round_effect_step,
@@ -43,5 +43,6 @@ __all__ = [
     "continue_round_effect_step",
     "calculate_final_score",
     "load_deck",
+    "select_random_deck",
     "RandomStrategy",
 ]

--- a/shadow_bout/cards.py
+++ b/shadow_bout/cards.py
@@ -1,4 +1,5 @@
 import json
+import random
 from pathlib import Path
 
 from shadow_bout.models import Card, Effect, EffectType, Janken
@@ -42,3 +43,11 @@ def load_deck(
         return [id_to_card[cid] for cid in card_ids if cid in id_to_card]
 
     return all_cards
+
+
+def select_random_deck(
+    size: int = 13, jsonl_path: Path = Path("cards.jsonl")
+) -> list[Card]:
+    """cards.jsonl の全カードから重複なく size 枚をランダム抽選して返す。"""
+    all_cards = load_deck(jsonl_path=jsonl_path)
+    return random.sample(all_cards, size)

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -417,10 +417,13 @@ def _choose_npc_wildcard_janken(
     return _coerce_wildcard_janken(choose_effect(choices, game_state), Side.NPC)
 
 
-def init_game(deck: list[Card]) -> GameState:
-    """デッキをシャッフルし、手札5枚を配布した GameState を返す。"""
+def init_game(deck: list[Card], npc_deck: list[Card] | None = None) -> GameState:
+    """デッキをシャッフルし、手札5枚を配布した GameState を返す。
+
+    npc_deck を渡すと NPC は別デッキで初期化される。省略時は同一デッキを共有。
+    """
     p_deck = list(deck)
-    n_deck = list(deck)
+    n_deck = list(deck if npc_deck is None else npc_deck)
     random.shuffle(p_deck)
     random.shuffle(n_deck)
 
@@ -436,8 +439,8 @@ def init_game(deck: list[Card]) -> GameState:
     )
 
 
-def start_game(deck: list[Card]) -> GameState:
-    state = init_game(deck)
+def start_game(deck: list[Card], npc_deck: list[Card] | None = None) -> GameState:
+    state = init_game(deck, npc_deck)
     return replace(state, phase=Phase.SELECT)
 
 

--- a/tests/test_cards.py
+++ b/tests/test_cards.py
@@ -1,0 +1,39 @@
+import random
+
+from shadow_bout.cards import load_deck, select_random_deck
+
+
+def test_select_random_deck_returns_requested_size():
+    deck = select_random_deck(13)
+    assert len(deck) == 13
+
+
+def test_select_random_deck_no_duplicates_in_one_deck():
+    deck = select_random_deck(13)
+    ids = [c.id for c in deck]
+    assert len(set(ids)) == len(ids)
+
+
+def test_select_random_deck_picks_from_all_52_cards():
+    all_cards = load_deck()
+    all_ids = {c.id for c in all_cards}
+    deck = select_random_deck(13)
+    assert {c.id for c in deck}.issubset(all_ids)
+
+
+def test_select_random_deck_two_calls_can_overlap():
+    """プレイヤー / NPC それぞれ独立に抽選するので両デッキで同一カードがあり得る。"""
+    random.seed(0)
+    p_deck = select_random_deck(13)
+    n_deck = select_random_deck(13)
+    p_ids = {c.id for c in p_deck}
+    n_ids = {c.id for c in n_deck}
+    # シード固定で重なりが発生することを確認（実装が独立抽選であることの担保）
+    assert p_ids & n_ids
+
+
+def test_select_random_deck_two_calls_differ():
+    random.seed(1)
+    deck_a = select_random_deck(13)
+    deck_b = select_random_deck(13)
+    assert [c.id for c in deck_a] != [c.id for c in deck_b]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -225,6 +225,35 @@ def test_init_game(mock_cards):
     assert len(state.npc.deck) == 11
 
 
+def test_init_game_with_separate_npc_deck():
+    p_deck = [
+        Card("p1", "P1", "k", Janken.ROCK, 10),
+        Card("p2", "P2", "k", Janken.SCISSORS, 10),
+        Card("p3", "P3", "k", Janken.PAPER, 10),
+        Card("p4", "P4", "k", Janken.ROCK, 10),
+        Card("p5", "P5", "k", Janken.SCISSORS, 10),
+        Card("p6", "P6", "k", Janken.PAPER, 10),
+        Card("p7", "P7", "k", Janken.ROCK, 10),
+    ]
+    n_deck = [
+        Card("n1", "N1", "k", Janken.ROCK, 10),
+        Card("n2", "N2", "k", Janken.SCISSORS, 10),
+        Card("n3", "N3", "k", Janken.PAPER, 10),
+        Card("n4", "N4", "k", Janken.ROCK, 10),
+        Card("n5", "N5", "k", Janken.SCISSORS, 10),
+        Card("n6", "N6", "k", Janken.PAPER, 10),
+        Card("n7", "N7", "k", Janken.ROCK, 10),
+    ]
+
+    state = init_game(p_deck, n_deck)
+
+    player_ids = {c.id for c in state.player.hand + state.player.deck}
+    npc_ids = {c.id for c in state.npc.hand + state.npc.deck}
+    assert player_ids == {c.id for c in p_deck}
+    assert npc_ids == {c.id for c in n_deck}
+    assert player_ids.isdisjoint(npc_ids)
+
+
 def test_check_forfeit(mock_cards):
     p_empty = PlayerState(hand=[])
     p_has = PlayerState(hand=mock_cards)


### PR DESCRIPTION
## 概要

ゲーム開始画面に2種類のエンゲージモードを用意しました。

- **赤ボタン「シャドウバウト・エンゲージ（固定13枚）」**: 既存挙動。`CARD_IDS` で固定された13枚デッキで開始（プレイヤー / NPC 共通）
- **青ボタン「シャドウバウト・エンゲージ（ランダム13枚）」**: 全52枚から13枚をプレイヤー / NPC それぞれ独立に抽選。両者のデッキで同じカードが現れることもある

加えて、`CARD_IDS` を初期コミット d3de42e の13枚に戻しました（`card_03`, `card_33`, `card_49` を削除）。「もう一度遊ぶ」はモードを保持して同じデッキで再戦します。別の抽選結果で遊びたい場合はブラウザをリロードしてトップに戻ってからボタンを押してください。

## 変更点

- `app.py`: 2ボタン構成に変更、`key="engage_random"` のボタンに `.st-key-engage_random` セレクタで青系 CSS をスコープ。「もう一度遊ぶ」のモード分岐
- `shadow_bout/cards.py`: `select_random_deck(size=13)` を新設（`random.sample` で同一デッキ内重複を防止）
- `shadow_bout/engine.py`: `init_game` / `start_game` に `npc_deck` 引数を追加（省略時は従来どおり同一デッキ）
- `shadow_bout/__init__.py`: `select_random_deck` を公開
- `tests/test_cards.py`: 新規。サイズ・重複・全52枚プールからの抽選・両デッキで重なりが起こりうること等を検証
- `tests/test_engine.py`: `init_game(player_deck, npc_deck)` のテストを追加

## テスト

- [x] `.venv/bin/python -m pytest`（137 passed）
- [x] `ruff format` / `ruff check --fix --extend-select I`
- [x] Streamlit 起動 → 赤・青2ボタンが表示・押下可能
- [x] ランダムボタン押下時、固定デッキに含まれない名前（可憐 / 亜利沙 / 奈緒 等）が手札に出現することを Chrome MCP で確認
