### PR TITLE
feat(ui): REVEAL時に場へ自動スクロール（スマホ視認性向上）

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from html import escape
 from time import sleep
 
 import streamlit as st
+import streamlit.components.v1 as components
 
 from shadow_bout import (
     Janken,
@@ -714,7 +715,10 @@ def main():
             render_known_npc_hand(game_state)
 
             st.markdown("---")
-            st.markdown("#### ── 場 ──")
+            st.markdown(
+                "<div id='battle-field-anchor'></div>\n\n#### ── 場 ──",
+                unsafe_allow_html=True,
+            )
 
             battle_cols = st.columns([5, 2, 5])
             with battle_cols[0]:
@@ -787,6 +791,20 @@ def main():
 
             if game_state.phase == Phase.REVEAL:
                 res = game_state.current_battle
+                components.html(
+                    """
+                    <script>
+                      (function() {
+                        const doc = window.parent.document;
+                        const target = doc.getElementById('battle-field-anchor');
+                        if (target) {
+                          target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                        }
+                      })();
+                    </script>
+                    """,
+                    height=0,
+                )
                 st.markdown("---")
                 if res.outcome == RoundOutcome.WIN:
                     st.balloons()


### PR DESCRIPTION
## Summary

- スマホ幅(〜390px)で「エンゲージ」を押した瞬間、`── 場 ──` セクションがビューポート上端に来るよう自動スクロールを追加
- 3カラムの場 (`st.columns([5,2,5])`) がモバイルで縦折り返しになるため、これまでは結果ヘッダーまでスクロールするとNPCのカードが画面外で「何に勝ったのか」一望できなかった
- REVEAL フェーズ突入時のみ発火するので、SELECT(手札選択) の操作には影響しない
- PC幅ではスクロール量がほぼ0なので違和感なし

## Implementation

- 場セクションに `#battle-field-anchor` を埋め込み (app.py:717-721)
- REVEAL分岐の冒頭で `st.components.v1.html` 経由のスクリプトを実行し `scrollIntoView({behavior:'smooth', block:'start'})` を呼ぶ (app.py:792-806)
- `<script>` を実行するため `unsafe_allow_html` ではなく `components.html` を使用

## Test plan

- [x] 既存テスト全 137 件 PASS (`uv run pytest`)
- [x] スマホ幅 (390x844) でエンゲージ → スムーススクロールで場が画面上端、NPCのカード/結果ヘッダーが順に見える
- [x] PC幅 (1400x862) でエンゲージ → 場と結果ヘッダーが1画面に収まり、レイアウト崩れなし
- [x] 「次へ」で次ラウンドへ進む際、SELECT 画面ではスクロール発火しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)