### PR TITLE
feat(ui): NPC戦終了後にXシェアボタンを追加

### DIFF
--- a/app.py
+++ b/app.py
@@ -149,13 +149,20 @@ _ROUND_OUTCOME_LABEL = {
 
 def format_share_round_lines(game_state):
     lines = []
-    for i, res in enumerate(game_state.completed_battles, 1):
-        p_icon = JANKEN_ICONS.get(res.player_card.janken, "")
-        n_icon = JANKEN_ICONS.get(res.npc_card.janken, "")
-        lines.append(
-            f"R{i}: {res.player_card.name}{p_icon} vs "
-            f"{res.npc_card.name}{n_icon} → {_ROUND_OUTCOME_LABEL[res.outcome]}"
-        )
+    for record in game_state.completed_rounds:
+        n = record.round_number
+        if record.battle is not None:
+            res = record.battle
+            p_icon = JANKEN_ICONS.get(res.player_card.janken, "")
+            n_icon = JANKEN_ICONS.get(res.npc_card.janken, "")
+            lines.append(
+                f"R{n}: {res.player_card.name}{p_icon} vs "
+                f"{res.npc_card.name}{n_icon} → {_ROUND_OUTCOME_LABEL[res.outcome]}"
+            )
+        elif record.forfeiting_side == Side.PLAYER:
+            lines.append(f"R{n}: あなたの不戦敗 → 負け")
+        elif record.forfeiting_side == Side.NPC:
+            lines.append(f"R{n}: NPCの不戦敗 → 勝ち")
     return lines
 
 

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import json
 from html import escape
 from time import sleep
 
@@ -136,6 +137,63 @@ def render_footer_links():
         - [もっと知る（ミリシタをダウンロード）](https://millionlive-theaterdays.idolmaster-official.jp/)
         - [このアプリのソースコード](https://github.com/ftnext/millionlive-shadow-bout)
         """
+    )
+
+
+_ROUND_OUTCOME_LABEL = {
+    RoundOutcome.WIN: "勝ち",
+    RoundOutcome.LOSE: "負け",
+    RoundOutcome.EVEN: "引き分け",
+}
+
+
+def format_share_round_lines(game_state):
+    lines = []
+    for i, res in enumerate(game_state.completed_battles, 1):
+        p_icon = JANKEN_ICONS.get(res.player_card.janken, "")
+        n_icon = JANKEN_ICONS.get(res.npc_card.janken, "")
+        lines.append(
+            f"R{i}: {res.player_card.name}{p_icon} vs "
+            f"{res.npc_card.name}{n_icon} → {_ROUND_OUTCOME_LABEL[res.outcome]}"
+        )
+    return lines
+
+
+def build_share_text(game_state, p_score, n_score, outcome_text):
+    header = f"陰界戦戯でNPCに{outcome_text}"
+    rounds = format_share_round_lines(game_state)
+    score = f"最終: あなた {p_score}pt / NPC {n_score}pt"
+    return "\n".join([header, *rounds, score])
+
+
+def render_share_button(game_state, p_score, n_score, outcome_text):
+    text = build_share_text(game_state, p_score, n_score, outcome_text)
+    text_json = json.dumps(text)
+    hashtags_json = json.dumps("陰界戦戯")
+    components.html(
+        f"""
+        <a id="tweetLink" href="#" target="_blank" rel="noopener"
+           style="display:inline-flex;align-items:center;padding:.5em 1em;
+                  background:#000;color:#fff;text-decoration:none;
+                  border-radius:9999px;font-weight:bold;font-size:14px;">
+            <svg viewBox="0 0 24 24" style="height:18px;fill:#fff;margin-right:8px;">
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 22.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.008 5.96H5.078z"/>
+            </svg>
+            結果をXでポスト
+        </a>
+        <script>
+            (function() {{
+                const link = document.getElementById('tweetLink');
+                link.addEventListener('click', function() {{
+                    const text = encodeURIComponent({text_json});
+                    const url = encodeURIComponent(window.parent.location.href);
+                    const tags = encodeURIComponent({hashtags_json});
+                    this.href = `https://twitter.com/intent/tweet?text=${{text}}&url=${{url}}&hashtags=${{tags}}`;
+                }});
+            }})();
+        </script>
+        """,
+        height=55,
     )
 
 
@@ -927,6 +985,14 @@ def main():
                     st.session_state.game_state = start_game(st.session_state.deck)
                 st.session_state.selected_card_id = None
                 st.rerun()
+
+            if p_score > n_score:
+                outcome_text = "勝ちました！"
+            elif p_score < n_score:
+                outcome_text = "負けました..."
+            else:
+                outcome_text = "引き分けました"
+            render_share_button(game_state, p_score, n_score, outcome_text)
 
     with col2:
         st.subheader("📜 バトルログ")

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -726,8 +726,12 @@ def finalize_round_if_ready(state: GameState) -> GameState:
     # But wait, if removal_activated is True, we already consumed the round and cards were discarded/decked in the effect handler!
     # So we don't apply_battle_result if removal was activated!
     if state.removal_activated:
-        # Just proceed to REVEAL phase
-        return replace(state, phase=Phase.REVEAL)
+        completed = CompletedRound(round_number=state.round_number, battle=res)
+        return replace(
+            state,
+            phase=Phase.REVEAL,
+            completed_rounds=state.completed_rounds + (completed,),
+        )
 
     final_state = apply_battle_result(state, res)
 

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -122,7 +122,13 @@ def apply_battle_result(game_state: GameState, result: BattleResult) -> GameStat
         draw_stock=new_n_stock,
     )
 
-    return replace(game_state, player=new_player, npc=new_npc, current_battle=result)
+    return replace(
+        game_state,
+        player=new_player,
+        npc=new_npc,
+        current_battle=result,
+        completed_battles=game_state.completed_battles + (result,),
+    )
 
 
 def check_forfeit(player: PlayerState, npc: PlayerState) -> Side | None:

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -19,6 +19,7 @@ from shadow_bout.janken import judge_janken_values
 from shadow_bout.models import (
     BattleResult,
     Card,
+    CompletedRound,
     GameState,
     Janken,
     JankenResult,
@@ -122,12 +123,15 @@ def apply_battle_result(game_state: GameState, result: BattleResult) -> GameStat
         draw_stock=new_n_stock,
     )
 
+    completed = CompletedRound(
+        round_number=game_state.round_number, battle=result
+    )
     return replace(
         game_state,
         player=new_player,
         npc=new_npc,
         current_battle=result,
-        completed_battles=game_state.completed_battles + (result,),
+        completed_rounds=game_state.completed_rounds + (completed,),
     )
 
 
@@ -962,10 +966,14 @@ def proceed_to_next(game_state: GameState) -> GameState:
             return replace(round_state, phase=Phase.SELECT)
 
         game_state = apply_forfeit(round_state, forfeit_side)
+        forfeit_record = CompletedRound(
+            round_number=next_round, forfeiting_side=forfeit_side
+        )
         game_state = replace(
             game_state,
             battle_log=game_state.battle_log
             + [format_forfeit_log(next_round, forfeit_side)],
+            completed_rounds=game_state.completed_rounds + (forfeit_record,),
         )
         next_round += 1
 

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -174,6 +174,7 @@ class GameState:
     phase: Phase = Phase.START
     battle_log: list[str] = field(default_factory=list)
     current_battle: BattleResult | None = None
+    completed_battles: tuple[BattleResult, ...] = ()
     last_restart_round: int | None = None
     effect_step: int = 0
     pending_effect_context: PendingEffectContext | None = None

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -158,6 +158,16 @@ class BattleResult:
 
 
 @dataclass(frozen=True)
+class CompletedRound:
+    """1ラウンドの最終的な経過。通常決着なら `battle` に BattleResult、
+    不戦敗で進行したラウンドなら `forfeiting_side` がセットされる。"""
+
+    round_number: int
+    battle: BattleResult | None = None
+    forfeiting_side: Side | None = None
+
+
+@dataclass(frozen=True)
 class PendingEffectContext:
     side: Side
     card_id: str
@@ -174,7 +184,7 @@ class GameState:
     phase: Phase = Phase.START
     battle_log: list[str] = field(default_factory=list)
     current_battle: BattleResult | None = None
-    completed_battles: tuple[BattleResult, ...] = ()
+    completed_rounds: tuple[CompletedRound, ...] = ()
     last_restart_round: int | None = None
     effect_step: int = 0
     pending_effect_context: PendingEffectContext | None = None

--- a/tests/effects/test_interactive_misc.py
+++ b/tests/effects/test_interactive_misc.py
@@ -5,6 +5,7 @@ from shadow_bout.engine import (
 )
 from shadow_bout.models import (
     Card,
+    CompletedRound,
     Effect,
     EffectType,
     GameState,
@@ -203,3 +204,6 @@ def test_resume_removal_effect_skips_winner_and_moves_cards():
     assert state.npc.discard == [other]
     assert state.player.won_cards == []
     assert state.npc.won_cards == []
+    assert state.completed_rounds == (
+        CompletedRound(round_number=state.round_number, battle=state.current_battle),
+    )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,3 +1,5 @@
+from dataclasses import replace
+
 import pytest
 
 from shadow_bout.engine import (
@@ -14,6 +16,7 @@ from shadow_bout.models import (
     BattleJankenOverride,
     BattleResult,
     Card,
+    CompletedRound,
     Effect,
     EffectType,
     GameState,
@@ -316,11 +319,12 @@ def test_apply_battle_result_npc_win_moves_cards_by_rule(mock_cards):
     assert new_state.npc.draw_stock == []
 
 
-def test_apply_battle_result_appends_to_completed_battles(mock_cards):
+def test_apply_battle_result_appends_to_completed_rounds(mock_cards):
     p_card, n_card, p_stock, n_stock = mock_cards
     state = GameState(
         player=PlayerState(hand=[p_card], draw_stock=[p_stock]),
         npc=PlayerState(hand=[n_card], draw_stock=[n_stock]),
+        round_number=1,
     )
     win_result = BattleResult(
         outcome=RoundOutcome.WIN,
@@ -332,9 +336,12 @@ def test_apply_battle_result_appends_to_completed_battles(mock_cards):
 
     after_win = apply_battle_result(state, win_result)
 
-    assert state.completed_battles == ()
-    assert after_win.completed_battles == (win_result,)
+    assert state.completed_rounds == ()
+    assert after_win.completed_rounds == (
+        CompletedRound(round_number=1, battle=win_result),
+    )
 
+    after_win = replace(after_win, round_number=2)
     even_result = BattleResult(
         outcome=RoundOutcome.EVEN,
         winning_side=None,
@@ -344,7 +351,10 @@ def test_apply_battle_result_appends_to_completed_battles(mock_cards):
     )
     after_even = apply_battle_result(after_win, even_result)
 
-    assert after_even.completed_battles == (win_result, even_result)
+    assert after_even.completed_rounds == (
+        CompletedRound(round_number=1, battle=win_result),
+        CompletedRound(round_number=2, battle=even_result),
+    )
     assert after_even.current_battle == even_result
 
 
@@ -459,6 +469,11 @@ def test_proceed_to_next_resolves_remaining_forfeit_rounds(mock_cards):
         "R3: あなたは不戦敗。NPCが勝ち札を獲得。",
         "R4: あなたは不戦敗。NPCが勝ち札を獲得。",
     ]
+    assert new_state.completed_rounds == (
+        CompletedRound(round_number=2, forfeiting_side=Side.PLAYER),
+        CompletedRound(round_number=3, forfeiting_side=Side.PLAYER),
+        CompletedRound(round_number=4, forfeiting_side=Side.PLAYER),
+    )
 
 
 def test_proceed_to_next_ends_when_both_players_cannot_play(mock_cards):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -316,6 +316,38 @@ def test_apply_battle_result_npc_win_moves_cards_by_rule(mock_cards):
     assert new_state.npc.draw_stock == []
 
 
+def test_apply_battle_result_appends_to_completed_battles(mock_cards):
+    p_card, n_card, p_stock, n_stock = mock_cards
+    state = GameState(
+        player=PlayerState(hand=[p_card], draw_stock=[p_stock]),
+        npc=PlayerState(hand=[n_card], draw_stock=[n_stock]),
+    )
+    win_result = BattleResult(
+        outcome=RoundOutcome.WIN,
+        winning_side=Side.PLAYER,
+        player_card=p_card,
+        npc_card=n_card,
+        janken_result=JankenResult.WIN,
+    )
+
+    after_win = apply_battle_result(state, win_result)
+
+    assert state.completed_battles == ()
+    assert after_win.completed_battles == (win_result,)
+
+    even_result = BattleResult(
+        outcome=RoundOutcome.EVEN,
+        winning_side=None,
+        player_card=p_stock,
+        npc_card=n_stock,
+        janken_result=JankenResult.DRAW,
+    )
+    after_even = apply_battle_result(after_win, even_result)
+
+    assert after_even.completed_battles == (win_result, even_result)
+    assert after_even.current_battle == even_result
+
+
 def test_proceed_to_next_resets_round_local_state(mock_cards):
     p_card, n_card, _, revealed_card = mock_cards
     battle = BattleResult(


### PR DESCRIPTION
## Summary

- `Phase.RESULT` 画面の「もう一度遊ぶ」ボタンの下に、X (Twitter) Web Intent で結果をポストできるボタンを追加
- 投稿本文には全体の勝敗・4ラウンドの経過 (`R1: 真✊ vs 千鶴✌️ → 勝ち` のようにカード名+じゃんけんアイコン+勝/負/引き分け)・最終スコア・アプリURL・ハッシュタグ `#陰界戦戯` を含める
- 各ラウンドの最終結果を確実に取得するため `GameState.completed_battles: tuple[BattleResult, ...]` を追加し、`apply_battle_result` で蓄積

## 投稿フォーマット例

```
陰界戦戯でNPCに勝ちました！
R1: 真✊ vs 千鶴✌️ → 勝ち
R2: 美奈子✋ vs 翼🃏 → 引き分け
R3: ...
R4: ...
最終: あなた 5pt / NPC 3pt
```
URL は `window.parent.location.href` から取得 (Streamlit iframe 対策)。

## Test plan

- [x] `uv run pytest` (138 passed; `completed_battles` 蓄積テスト追加済)
- [ ] `streamlit run app.py` で 4 ラウンド戦って `Phase.RESULT` まで到達し、ボタンが表示されることを確認
- [ ] ボタンクリックで新しいタブが開き、本文・URL・ハッシュタグが正しく入っていることを確認
- [ ] あいこ→ポイント比較で勝敗が決まったラウンドが「勝ち」/「負け」、完全引き分けは「引き分け」と表示されることを確認
- [ ] ランダムデッキモードでも動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)