### PR TITLE
feat(ui): add 主演公演 deck pools (全力援走 / Grand bal masqué)

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,53 @@ CARD_IDS = [
     "card_05",
 ]
 
+# 13thLIVE DAY1 全力援走 出演キャスト（主演: 高山紗代子）
+ZENRYOKU_CARD_IDS = [
+    "card_27",  # 紗代子（主演）
+    "card_14",  # 未来
+    "card_16",  # 翼
+    "card_18",  # エレナ
+    "card_21",  # まつり
+    "card_23",  # 茜
+    "card_30",  # 育
+    "card_36",  # 可奈
+    "card_37",  # 奈緒
+    "card_40",  # 環
+    "card_42",  # 美也
+    "card_43",  # のり子
+    "card_45",  # 可憐
+    "card_48",  # 麗花
+]
+
+# 13thLIVE DAY2 Grand bal masqué 出演キャスト（主演: 二階堂千鶴）
+GRAND_BAL_CARD_IDS = [
+    "card_38",  # 千鶴（主演）
+    "card_19",  # 美奈子
+    "card_25",  # ロコ
+    "card_31",  # 朋花
+    "card_39",  # このみ
+    "card_41",  # 風花
+    "card_44",  # 瑞希
+    "card_46",  # 莉緒
+    "card_47",  # 昴
+    "card_49",  # 桃子
+    "card_50",  # ジュリア
+    "card_51",  # 紬
+    "card_52",  # 歌織
+]
+
+DECK_POOL_NAMA_HAISHIN = "生配信ver（13枚）"
+DECK_POOL_ZENRYOKU = "全力援走（DAY1・14枚）"
+DECK_POOL_GRAND_BAL = "Grand bal masqué（DAY2・13枚）"
+
+# プール名 → (player_card_ids, npc_card_ids)。主演公演同士は対戦相手として入れ替え。
+DECK_POOLS: dict[str, tuple[list[str], list[str]]] = {
+    DECK_POOL_NAMA_HAISHIN: (CARD_IDS, CARD_IDS),
+    DECK_POOL_ZENRYOKU: (ZENRYOKU_CARD_IDS, GRAND_BAL_CARD_IDS),
+    DECK_POOL_GRAND_BAL: (GRAND_BAL_CARD_IDS, ZENRYOKU_CARD_IDS),
+}
+SHOEN_POOL_NAMES = {DECK_POOL_ZENRYOKU, DECK_POOL_GRAND_BAL}
+
 JANKEN_ICONS = {
     Janken.ROCK: "✊",
     Janken.SCISSORS: "✌️",
@@ -737,15 +784,59 @@ def main():
                 """,
                 unsafe_allow_html=True,
             )
+            pool_label = st.selectbox(
+                "デッキプール（固定）",
+                list(DECK_POOLS.keys()),
+                index=0,
+                key="deck_pool_label",
+            )
+            player_ids, npc_ids = DECK_POOLS[pool_label]
+            if pool_label in SHOEN_POOL_NAMES:
+                opponent_label = (
+                    DECK_POOL_GRAND_BAL
+                    if pool_label == DECK_POOL_ZENRYOKU
+                    else DECK_POOL_ZENRYOKU
+                )
+                st.caption(
+                    f"⚠ 主演公演プールは13枚を超えてもよしとします（無法ルール）。"
+                    f" 対戦相手は **{opponent_label}**、主演は必ず初期手札に入ります。"
+                )
+
             if st.button(
-                "シャドウバウト・エンゲージ（固定13枚）",
+                "シャドウバウト・エンゲージ（固定）",
                 type="primary",
                 use_container_width=True,
                 key="engage_fixed",
             ):
                 clear_reorder_widget_state()
-                st.session_state.game_mode = "fixed"
-                st.session_state.game_state = start_game(st.session_state.deck)
+                p_deck = load_deck(player_ids)
+                n_deck = load_deck(npc_ids)
+                if pool_label in SHOEN_POOL_NAMES:
+                    p_must = [p_deck[0]]
+                    n_must = [n_deck[0]]
+                    st.session_state.game_mode = (
+                        "fixed_zenryoku"
+                        if pool_label == DECK_POOL_ZENRYOKU
+                        else "fixed_grandbal"
+                    )
+                    npc_deck_arg = n_deck
+                else:
+                    p_must, n_must = None, None
+                    st.session_state.game_mode = "fixed"
+                    npc_deck_arg = None
+
+                st.session_state.player_deck = p_deck
+                st.session_state.npc_deck = n_deck
+                st.session_state.player_must_in_hand = p_must
+                st.session_state.npc_must_in_hand = n_must
+                st.session_state.deck = p_deck
+
+                st.session_state.game_state = start_game(
+                    p_deck,
+                    npc_deck_arg,
+                    player_must_in_hand=p_must,
+                    npc_must_in_hand=n_must,
+                )
                 st.session_state.selected_card_id = None
                 st.rerun()
             if st.button(
@@ -985,10 +1076,18 @@ def main():
 
             if st.button("もう一度遊ぶ", use_container_width=True):
                 clear_reorder_widget_state()
-                if st.session_state.get("game_mode") == "random":
+                mode = st.session_state.get("game_mode")
+                if mode == "random":
                     st.session_state.game_state = start_game(
                         st.session_state.player_deck,
                         st.session_state.npc_deck,
+                    )
+                elif mode in {"fixed_zenryoku", "fixed_grandbal"}:
+                    st.session_state.game_state = start_game(
+                        st.session_state.player_deck,
+                        st.session_state.npc_deck,
+                        player_must_in_hand=st.session_state.player_must_in_hand,
+                        npc_must_in_hand=st.session_state.npc_must_in_hand,
                     )
                 else:
                     st.session_state.game_state = start_game(st.session_state.deck)

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -123,9 +123,7 @@ def apply_battle_result(game_state: GameState, result: BattleResult) -> GameStat
         draw_stock=new_n_stock,
     )
 
-    completed = CompletedRound(
-        round_number=game_state.round_number, battle=result
-    )
+    completed = CompletedRound(round_number=game_state.round_number, battle=result)
     return replace(
         game_state,
         player=new_player,
@@ -427,15 +425,54 @@ def _choose_npc_wildcard_janken(
     return _coerce_wildcard_janken(choose_effect(choices, game_state), Side.NPC)
 
 
-def init_game(deck: list[Card], npc_deck: list[Card] | None = None) -> GameState:
+def _ensure_in_top(
+    deck: list[Card], required: list[Card] | None, top_n: int = 5
+) -> list[Card]:
+    """required の各カードが deck[:top_n] に確実に入るよう、必要なら top_n 内のカードと入れ替える。
+
+    required にあるが deck に存在しないカードは無視する。required 同士の入れ替えは行わない。
+    """
+    if not required:
+        return deck
+    deck = list(deck)
+    required_ids = {c.id for c in required}
+    top = deck[:top_n]
+    rest = deck[top_n:]
+    top_ids = {c.id for c in top}
+    for card in required:
+        if card.id in top_ids:
+            continue
+        rest_idx = next((i for i, c in enumerate(rest) if c.id == card.id), None)
+        if rest_idx is None:
+            continue
+        swap_candidates = [i for i, c in enumerate(top) if c.id not in required_ids]
+        if not swap_candidates:
+            continue
+        top_idx = random.choice(swap_candidates)
+        top[top_idx], rest[rest_idx] = rest[rest_idx], top[top_idx]
+        top_ids = {c.id for c in top}
+    return top + rest
+
+
+def init_game(
+    deck: list[Card],
+    npc_deck: list[Card] | None = None,
+    player_must_in_hand: list[Card] | None = None,
+    npc_must_in_hand: list[Card] | None = None,
+) -> GameState:
     """デッキをシャッフルし、手札5枚を配布した GameState を返す。
 
     npc_deck を渡すと NPC は別デッキで初期化される。省略時は同一デッキを共有。
+    player_must_in_hand / npc_must_in_hand を指定すると、各サイドの初期手札に
+    必ずそれらのカードが含まれるよう、シャッフル後に入れ替えを行う。
     """
     p_deck = list(deck)
     n_deck = list(deck if npc_deck is None else npc_deck)
     random.shuffle(p_deck)
     random.shuffle(n_deck)
+
+    p_deck = _ensure_in_top(p_deck, player_must_in_hand, top_n=5)
+    n_deck = _ensure_in_top(n_deck, npc_must_in_hand, top_n=5)
 
     p_hand = p_deck[:5]
     p_deck = p_deck[5:]
@@ -449,8 +486,18 @@ def init_game(deck: list[Card], npc_deck: list[Card] | None = None) -> GameState
     )
 
 
-def start_game(deck: list[Card], npc_deck: list[Card] | None = None) -> GameState:
-    state = init_game(deck, npc_deck)
+def start_game(
+    deck: list[Card],
+    npc_deck: list[Card] | None = None,
+    player_must_in_hand: list[Card] | None = None,
+    npc_must_in_hand: list[Card] | None = None,
+) -> GameState:
+    state = init_game(
+        deck,
+        npc_deck,
+        player_must_in_hand=player_must_in_hand,
+        npc_must_in_hand=npc_must_in_hand,
+    )
     return replace(state, phase=Phase.SELECT)
 
 

--- a/tests/test_init_game_must_in_hand.py
+++ b/tests/test_init_game_must_in_hand.py
@@ -1,0 +1,95 @@
+import random
+
+import pytest
+
+from shadow_bout.engine import init_game, start_game
+from shadow_bout.models import Card, Janken, Phase
+
+
+def _make_deck(size: int) -> list[Card]:
+    return [
+        Card(f"card_{i:02d}", f"name{i}", f"kana{i}", Janken.ROCK, 10)
+        for i in range(size)
+    ]
+
+
+def test_player_must_in_hand_always_in_starting_hand():
+    deck = _make_deck(14)
+    must = [deck[0]]
+
+    for seed in range(50):
+        random.seed(seed)
+        state = init_game(deck, player_must_in_hand=must)
+        hand_ids = {c.id for c in state.player.hand}
+        assert must[0].id in hand_ids, f"seed {seed}: lead missing from hand"
+        assert len(state.player.hand) == 5
+        assert len(state.player.deck) == len(deck) - 5
+
+
+def test_npc_must_in_hand_always_in_starting_hand():
+    p_deck = _make_deck(14)
+    n_deck = _make_deck(13)
+    p_must = [p_deck[0]]
+    n_must = [n_deck[0]]
+
+    for seed in range(50):
+        random.seed(seed)
+        state = init_game(
+            p_deck,
+            n_deck,
+            player_must_in_hand=p_must,
+            npc_must_in_hand=n_must,
+        )
+        assert p_must[0].id in {c.id for c in state.player.hand}
+        assert n_must[0].id in {c.id for c in state.npc.hand}
+        assert len(state.npc.hand) == 5
+        assert len(state.npc.deck) == len(n_deck) - 5
+
+
+def test_must_in_hand_card_not_in_deck_is_silently_ignored():
+    deck = _make_deck(13)
+    foreign = Card("foreign_id", "x", "x", Janken.ROCK, 10)
+    state = init_game(deck, player_must_in_hand=[foreign])
+    assert len(state.player.hand) == 5
+    assert all(c.id != foreign.id for c in state.player.hand)
+
+
+def test_start_game_propagates_must_in_hand():
+    deck = _make_deck(14)
+    must = [deck[0]]
+    random.seed(0)
+    state = start_game(deck, player_must_in_hand=must)
+    assert state.phase == Phase.SELECT
+    assert must[0].id in {c.id for c in state.player.hand}
+
+
+def test_must_in_hand_default_none_preserves_existing_behavior():
+    deck = _make_deck(13)
+    random.seed(123)
+    state = init_game(deck)
+    assert len(state.player.hand) == 5
+    assert len(state.player.deck) == 8
+    assert len(state.npc.hand) == 5
+    assert len(state.npc.deck) == 8
+
+
+def test_multiple_required_cards_all_land_in_hand():
+    deck = _make_deck(14)
+    must = [deck[0], deck[1], deck[2]]
+    for seed in range(20):
+        random.seed(seed)
+        state = init_game(deck, player_must_in_hand=must)
+        hand_ids = {c.id for c in state.player.hand}
+        for required in must:
+            assert required.id in hand_ids
+
+
+@pytest.mark.parametrize("seed", range(20))
+def test_must_in_hand_does_not_duplicate_cards(seed):
+    deck = _make_deck(14)
+    must = [deck[0]]
+    random.seed(seed)
+    state = init_game(deck, player_must_in_hand=must)
+    all_ids = [c.id for c in state.player.hand] + [c.id for c in state.player.deck]
+    assert len(all_ids) == len(deck)
+    assert len(set(all_ids)) == len(deck)


### PR DESCRIPTION
## 概要

13thLIVE DAY1 全力援走 に現地参戦してあまりにも良かったのを動機に、固定モードに**主演公演デッキプール**を追加します。

固定モードのスタート画面に「デッキプール（固定）」プルダウンを設置し、3種類から選べます：

- **生配信ver（13枚）** — 既存挙動（デフォルト）
- **全力援走（DAY1・14枚）** — 主演: 高山紗代子。**対戦相手は Grand bal masqué**
- **Grand bal masqué（DAY2・13枚）** — 主演: 二階堂千鶴。**対戦相手は全力援走**

主演公演プールは**無法ルール**として **13枚を超えてもよし**、また **主演（紗代子 / 千鶴）は必ずゲーム開始時の手札に入る**。

公式情報: <https://idolmaster-official.jp/live_event/million13th/information/>

## 実装

- `shadow_bout/engine.py`: `init_game` / `start_game` に `player_must_in_hand` / `npc_must_in_hand` kwargs を追加。シャッフル後の `_ensure_in_top` で必須カードを top 5 に確実に含める。既存呼び出しはキーワード省略時に挙動不変。
- `app.py`: `ZENRYOKU_CARD_IDS`（14件、紗代子 先頭）と `GRAND_BAL_CARD_IDS`（13件、千鶴 先頭）の定数、`DECK_POOLS` マップ、プルダウン UI を追加。`game_mode` に `fixed_zenryoku` / `fixed_grandbal` を導入し「もう一度遊ぶ」リプレイでも主演強制配置を再現。ボタンラベルは「（固定13枚）」→「（固定）」に短縮。
- `tests/test_init_game_must_in_hand.py`: 主演強制配置・存在しないカード無視・既存挙動非破壊・複数 required・カード重複なしを確認。

## テスト

- [x] `./.venv/bin/python -m pytest`（164 件 全通）
- [x] `ruff format` / `ruff check --fix --extend-select I`
- [x] 動作確認（streamlit 起動 → 各プール選択 → 主演が手札に入ること、リプレイで再現すること）
