### PR TITLE
fix(effects): 茜 (card_23) のテキスト欠落と対象side反転

### DIFF
--- a/app.py
+++ b/app.py
@@ -708,16 +708,17 @@ def render_pending_effect_form(game_state):
         return
 
     if ctx.effect == "reorder":
-        options, labels = card_id_options(player.deck)
+        opponent = game_state.npc if ctx.side == Side.PLAYER else game_state.player
+        options, labels = card_id_options(opponent.deck)
         if len(options) <= 1:
-            st.info("並び替える山札がありません。")
+            st.info("並び替える相手の山札がありません。")
             if st.button("次へ", type="primary", use_container_width=True):
                 submit_effect_choice(game_state, None)
             return
 
         reorder_key = f"reorder_deck_cards_{game_state.round_number}_{ctx.card_id}_{ctx.side.value}"
         ordered_ids = st.multiselect(
-            "山札の上から順にカードを選択",
+            "相手の山札の上から順にカードを選択",
             options,
             default=options,
             format_func=lambda card_id: labels[card_id],
@@ -726,7 +727,7 @@ def render_pending_effect_form(game_state):
         )
         is_ready = len(ordered_ids) == len(options)
         if not is_ready:
-            st.caption("山札の全カードを順番どおりに選択してください。")
+            st.caption("相手の山札の全カードを順番どおりに選択してください。")
         if st.button(
             "この順番にする",
             type="primary",

--- a/cards.jsonl
+++ b/cards.jsonl
@@ -20,7 +20,7 @@
 {"id": "card_20", "name": "恵美", "kana": "めぐみ", "janken": "rock", "basePoint": 11, "effect": {"description": "お互いに山札から2枚引く。", "type": "draw", "value": 2}}
 {"id": "card_21", "name": "まつり", "kana": "まつり", "janken": "rock", "basePoint": 19, "effect": {"description": "自分のポイント+1する。", "type": "buff", "value": 1}}
 {"id": "card_22", "name": "星梨花", "kana": "せりか", "janken": "rock", "basePoint": 13, "effect": {"description": "相手の山札の上から1枚めくり、そのカードを自分の手札に加える。", "type": "steal_draw", "value": 1}}
-{"id": "card_23", "name": "茜", "kana": "あかね", "janken": "paper", "basePoint": 13, "effect": {"description": "好きな順番で入れ替えることができる。", "type": "reorder", "value": null}}
+{"id": "card_23", "name": "茜", "kana": "あかね", "janken": "paper", "basePoint": 13, "effect": {"description": "相手の山札を全て確認し、好きな順番で入れ替えることができる。", "type": "reorder", "value": null}}
 {"id": "card_24", "name": "杏奈", "kana": "あんな", "janken": "rock", "basePoint": 17, "effect": {"description": "自分の手札を1枚選び、相手に見せることで、そのカードの戦具の効果を発動する。見せたカードは手札に戻す。", "type": "copy_hand", "value": null}}
 {"id": "card_25", "name": "ロコ", "kana": "ろこ", "janken": "rock", "basePoint": 15, "effect": {"description": "相手の手札を1枚ランダムに選ぶ。そのカードは以降公開した状態で扱う。", "type": "reveal", "value": 1}}
 {"id": "card_26", "name": "百合子", "kana": "ゆりこ", "janken": "paper", "basePoint": 15, "effect": {"description": "どちらかの効果を選んで発動する。●自分のポイント+3する。●山札から2枚引く。その後、手札を2枚選び、山札の一番下に置く。", "type": "choose", "value": null}}

--- a/shadow_bout/effect_handlers/interactive.py
+++ b/shadow_bout/effect_handlers/interactive.py
@@ -6,6 +6,7 @@ from shadow_bout.effect_handlers.common import (
 )
 from shadow_bout.effect_handlers.registry import register
 from shadow_bout.effect_utils import (
+    get_opponent_side,
     get_player_state,
 )
 from shadow_bout.models import (
@@ -155,12 +156,12 @@ def effect_salvage(state: GameState, side: Side, card: Card) -> GameState:
 
 @register("reorder")
 def effect_reorder(state: GameState, side: Side, card: Card) -> GameState:
-    p_state = get_player_state(state, side)
-    if len(p_state.deck) <= 1:
+    opponent_state = get_player_state(state, get_opponent_side(side))
+    if len(opponent_state.deck) <= 1:
         return replace(
             state,
             battle_log=state.battle_log
-            + [f"{card.name}の効果発動: 並び替える山札がないため不発"],
+            + [f"{card.name}の効果発動: 並び替える相手の山札がないため不発"],
         )
 
     ctx = PendingEffectContext(side=side, card_id=card.id, effect="reorder")
@@ -169,5 +170,6 @@ def effect_reorder(state: GameState, side: Side, card: Card) -> GameState:
     )
     return replace(
         state,
-        battle_log=state.battle_log + [f"{card.name}の効果発動: 並び替え待機中..."],
+        battle_log=state.battle_log
+        + [f"{card.name}の効果発動: 相手山札の並び替え待機中..."],
     )

--- a/shadow_bout/effect_handlers/resume_cards.py
+++ b/shadow_bout/effect_handlers/resume_cards.py
@@ -178,20 +178,23 @@ def _resume_salvage(state: GameState, side: Side, choice: str | None) -> GameSta
 
 
 def _resume_reorder(state: GameState, side: Side, choice: str | None) -> GameState:
-    p_state = get_player_state(state, side)
-    if not p_state.deck:
-        return _finish_interactive_effect(state, "-> 茜の効果: 並び替える山札がない")
+    opponent_side = get_opponent_side(side)
+    opponent_state = get_player_state(state, opponent_side)
+    if not opponent_state.deck:
+        return _finish_interactive_effect(
+            state, "-> 茜の効果: 並び替える相手の山札がない"
+        )
 
     selected_ids = _parse_card_ids(choice)
     ordered: list[Card] = []
     used_ids: set[str] = set()
     for card_id in selected_ids:
-        card = _find_card(p_state.deck, card_id)
+        card = _find_card(opponent_state.deck, card_id)
         if card is None or card.id in used_ids:
             continue
         ordered.append(card)
         used_ids.add(card.id)
 
-    ordered.extend(card for card in p_state.deck if card.id not in used_ids)
-    state = update_player(state, side, deck=ordered)
-    return _finish_interactive_effect(state, "-> 茜の効果: 山札の順番を入れ替えた")
+    ordered.extend(card for card in opponent_state.deck if card.id not in used_ids)
+    state = update_player(state, opponent_side, deck=ordered)
+    return _finish_interactive_effect(state, "-> 茜の効果: 相手の山札の順番を入れ替えた")

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -931,7 +931,8 @@ def _choose_npc_pending_effect(
         return npc_strategy.select_target(npc.discard, state).id
 
     if ctx.effect == "reorder":
-        shuffled = list(npc.deck)
+        player = get_player_state(state, Side.PLAYER)
+        shuffled = list(player.deck)
         random.shuffle(shuffled)
         return ",".join(card.id for card in shuffled)
 

--- a/tests/effects/test_interactive_misc.py
+++ b/tests/effects/test_interactive_misc.py
@@ -30,8 +30,8 @@ def test_resume_reorder_effect_applies_player_selected_order():
     d2 = Card("d2", "draw2", "どろー2", Janken.SCISSORS, 3)
     d3 = Card("d3", "draw3", "どろー3", Janken.PAPER, 4)
     state = GameState(
-        player=PlayerState(hand=[akane], deck=[d1, d2, d3]),
-        npc=PlayerState(hand=[other]),
+        player=PlayerState(hand=[akane]),
+        npc=PlayerState(hand=[other], deck=[d1, d2, d3]),
     )
 
     state = resolve_round(state, akane, other)
@@ -40,7 +40,7 @@ def test_resume_reorder_effect_applies_player_selected_order():
     state = resume_round_effect(state, choice="d3,d1,d2")
 
     assert state.phase == Phase.REVEAL
-    assert [card.id for card in state.player.deck] == ["d3", "d1", "d2"]
+    assert [card.id for card in state.npc.deck] == ["d3", "d1", "d2"]
 
 
 def test_resume_salvage_effect_recovers_from_discard_with_penalty():

--- a/tests/effects/test_resolution_steps.py
+++ b/tests/effects/test_resolution_steps.py
@@ -182,12 +182,12 @@ def test_resolve_npc_pending_effects_progresses_reorder_without_stop():
         Effect(EffectType.REORDER, "reorder", None),
     )
     other = Card("cx", "other", "おざー", Janken.PAPER, 14, None)
-    n1 = Card("n1", "npc1", "えぬ1", Janken.ROCK, 1)
-    n2 = Card("n2", "npc2", "えぬ2", Janken.SCISSORS, 2)
-    n3 = Card("n3", "npc3", "えぬ3", Janken.PAPER, 3)
+    p1 = Card("p1", "player1", "ぷれいやー1", Janken.ROCK, 1)
+    p2 = Card("p2", "player2", "ぷれいやー2", Janken.SCISSORS, 2)
+    p3 = Card("p3", "player3", "ぷれいやー3", Janken.PAPER, 3)
     state = GameState(
-        player=PlayerState(hand=[other]),
-        npc=PlayerState(hand=[akane], deck=[n1, n2, n3]),
+        player=PlayerState(hand=[other], deck=[p1, p2, p3]),
+        npc=PlayerState(hand=[akane]),
     )
 
     random.seed(0)
@@ -198,7 +198,7 @@ def test_resolve_npc_pending_effects_progresses_reorder_without_stop():
     state = resolve_npc_pending_effects(state, FirstChoiceStrategy())
 
     assert state.phase == Phase.REVEAL
-    assert [card.id for card in state.npc.deck] != ["n1", "n2", "n3"]
+    assert [card.id for card in state.player.deck] != ["p1", "p2", "p3"]
 
 
 def test_npc_interactive_effect_is_resolved_by_strategy():


### PR DESCRIPTION
## Summary

- `cards.jsonl` の 茜 (card_23) の効果テキストは OCR 由来で主語が欠落しており、原典 PDF を確認すると正しいテキストは **「相手の山札を全て確認し、好きな順番で入れ替えることができる。」** だった。
- テキスト欠落だけでなく、`reorder` 効果の実装が**自分の山札**を並び替える挙動になっていた（原文では相手の山札が対象）。テキスト修正に合わせて side を反転。

## Changes

- [cards.jsonl](cards.jsonl): 茜 の `effect.description` を完全な原文に更新
- [shadow_bout/effect_handlers/interactive.py](shadow_bout/effect_handlers/interactive.py): `effect_reorder` の不発判定を相手側 deck に対して行う
- [shadow_bout/effect_handlers/resume_cards.py](shadow_bout/effect_handlers/resume_cards.py): `_resume_reorder` で相手側 deck を更新
- [shadow_bout/engine.py](shadow_bout/engine.py): NPC が茜を出した時、シャッフル対象を `player.deck` に
- [app.py](app.py): Streamlit UI で対戦相手の deck を表示し、ラベルも「相手の山札の上から順に…」に
- `tests/effects/test_interactive_misc.py`, `tests/effects/test_resolution_steps.py`: 対象 side を反転したテストに更新

## Test plan

- [x] `uv run pytest` (164 passed)
- [ ] `uv run streamlit run app.py` で起動し、PLAYER のデッキに茜を含めて対戦
  - [ ] 茜 をあいこで発動させた時、効果選択 UI に **NPC の山札** が表示されること
  - [ ] 並び替えを確定すると NPC の山札の順序が反映されること
  - [ ] NPC 側が茜を出した場合、PLAYER の山札順序が変わる（battle log で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)