### PR TITLE
fix(effects): align 可憐 (card_45) effect with card text

### DIFF
--- a/app.py
+++ b/app.py
@@ -405,14 +405,14 @@ def render_pending_effect_form(game_state):
         if variant == "karen_choose":
             choice = st.radio(
                 "可憐の効果",
-                ["activate", "skip"],
+                ["gain_points", "return_and_flip"],
                 format_func=lambda value: {
-                    "activate": "発動する（相手の公開を2ラウンド強制）",
-                    "skip": "発動しない",
+                    "gain_points": "自分のポイント+2する",
+                    "return_and_flip": "このカードを山札に戻して切り、山札の上から1枚を場に出す（戦具効果は不発）",
                 }[value],
                 horizontal=True,
             )
-            if st.button("この効果を決定", type="primary", use_container_width=True):
+            if st.button("この効果を発動", type="primary", use_container_width=True):
                 submit_effect_choice(game_state, choice)
             return
 

--- a/shadow_bout/effect_handlers/resume_choices.py
+++ b/shadow_bout/effect_handlers/resume_choices.py
@@ -1,3 +1,4 @@
+import random
 from dataclasses import replace
 
 from shadow_bout.effect_handlers.common import (
@@ -11,7 +12,6 @@ from shadow_bout.effect_handlers.registry import get_effect_handler
 from shadow_bout.effect_utils import (
     get_opponent_side,
     get_player_state,
-    set_must_reveal_played_card_rounds,
     update_player,
 )
 from shadow_bout.models import GameState, Phase, PointMatchEffect, Side
@@ -84,17 +84,43 @@ def _resume_choose(state: GameState, side: Side, choice: str | None) -> GameStat
         return _finish_interactive_effect(state, "-> 百合子の効果: ポイント+3")
 
     if variant == "karen_choose":
-        if choice != "activate":
-            return _finish_interactive_effect(state, "-> 可憐の効果: 発動しない")
-        if _opponent_is_immune(state, side):
-            return _finish_interactive_effect(
-                state, "-> 可憐の効果: 相手は戦具効果を受けないため不発"
+        if choice == "gain_points":
+            state = update_player(
+                state, side, point_modifier=p_state.point_modifier + 2
             )
-        opp_side = get_opponent_side(side)
-        state = set_must_reveal_played_card_rounds(state, opp_side, rounds=2)
-        return _finish_interactive_effect(
-            state, "-> 可憐の効果: 相手は2ラウンドの間、出し札を公開"
-        )
+            return _finish_interactive_effect(state, "-> 可憐の効果: ポイント+2")
+
+        if choice == "return_and_flip":
+            res = state.current_battle
+            if res is None:
+                return _finish_interactive_effect(
+                    state, "-> 可憐の効果: 場のカードがないため不発"
+                )
+
+            old_card = res.player_card if side == Side.PLAYER else res.npc_card
+
+            shuffled = p_state.deck + [old_card]
+            random.shuffle(shuffled)
+            new_card = shuffled[0]
+            new_deck = shuffled[1:]
+
+            if side == Side.PLAYER:
+                new_res = replace(res, player_card=new_card)
+            else:
+                new_res = replace(res, npc_card=new_card)
+
+            state = update_player(state, side, deck=new_deck)
+            state = replace(state, current_battle=new_res)
+            if new_card.id == old_card.id:
+                return _finish_interactive_effect(
+                    state, "-> 可憐の効果: 山札を切ったが、再び可憐がめくれた"
+                )
+            return _finish_interactive_effect(
+                state,
+                f"-> 可憐の効果: 可憐を山札に戻し、{new_card.name}を場に出した(戦具効果は不発)",
+            )
+
+        return _finish_interactive_effect(state, "-> 可憐の効果: 発動しない")
 
     return _finish_interactive_effect(state, "-> 選択効果: 未対応カード")
 

--- a/shadow_bout/effect_utils.py
+++ b/shadow_bout/effect_utils.py
@@ -109,13 +109,3 @@ def set_must_reveal_played_card(
     state: GameState, side: Side, should_reveal: bool
 ) -> GameState:
     return update_player(state, side, must_reveal_played_card=should_reveal)
-
-
-def set_must_reveal_played_card_rounds(
-    state: GameState, side: Side, rounds: int
-) -> GameState:
-    return update_player(
-        state,
-        side,
-        must_reveal_played_card_rounds=max(0, rounds),
-    )

--- a/shadow_bout/engine.py
+++ b/shadow_bout/engine.py
@@ -334,38 +334,17 @@ def apply_must_reveal_played_card(
     revealed_cards: list[Card] = []
     revealed_side: Side | None = None
 
-    player_must_reveal = (
-        game_state.player.must_reveal_played_card
-        or game_state.player.must_reveal_played_card_rounds > 0
-    )
-    npc_must_reveal = (
-        game_state.npc.must_reveal_played_card
-        or game_state.npc.must_reveal_played_card_rounds > 0
-    )
-
-    if player_must_reveal:
+    if game_state.player.must_reveal_played_card:
         revealed_cards.append(player_card)
         revealed_side = Side.PLAYER
-    if npc_must_reveal:
+    if game_state.npc.must_reveal_played_card:
         revealed_cards.append(npc_card)
         revealed_side = Side.NPC if revealed_side is None else None
 
     return replace(
         game_state,
-        player=replace(
-            game_state.player,
-            must_reveal_played_card=False,
-            must_reveal_played_card_rounds=max(
-                game_state.player.must_reveal_played_card_rounds - 1, 0
-            ),
-        ),
-        npc=replace(
-            game_state.npc,
-            must_reveal_played_card=False,
-            must_reveal_played_card_rounds=max(
-                game_state.npc.must_reveal_played_card_rounds - 1, 0
-            ),
-        ),
+        player=replace(game_state.player, must_reveal_played_card=False),
+        npc=replace(game_state.npc, must_reveal_played_card=False),
         revealed_this_round=revealed_cards or None,
         revealed_this_round_side=revealed_side,
     )
@@ -863,9 +842,7 @@ def _choose_npc_pending_effect(
         if variant == "yuriko_choose":
             return npc_strategy.choose_effect(["gain_points", "draw_cards"], state)
         if variant == "karen_choose":
-            if source_card and npc_strategy.should_activate(source_card, state):
-                return "activate"
-            return "skip"
+            return npc_strategy.choose_effect(["gain_points", "return_and_flip"], state)
         return None
 
     if ctx.effect == "copy_hand":

--- a/shadow_bout/models.py
+++ b/shadow_bout/models.py
@@ -130,7 +130,6 @@ class PlayerState:
     banned_card_ids: frozenset[str] = frozenset()
     forced_card_id: str | None = None
     must_reveal_played_card: bool = False
-    must_reveal_played_card_rounds: int = 0
     persistent_point_effects: tuple["PersistentPointEffect", ...] = ()
 
 

--- a/tests/effects/test_point_conditionals.py
+++ b/tests/effects/test_point_conditionals.py
@@ -1,6 +1,9 @@
+import random
+
 from shadow_bout.effects import calculate_effective_point
 from shadow_bout.engine import (
     proceed_to_next,
+    resolve_npc_pending_effects,
     resolve_round,
     resume_round_effect,
 )
@@ -15,18 +18,23 @@ from shadow_bout.models import (
     PlayerState,
     RoundOutcome,
 )
+from tests.effects.helpers import FirstChoiceStrategy
 
 
-def test_karen_choose_activate_sets_must_reveal_on_opponent():
-    karen = Card(
-        "c45",
+def _karen() -> Card:
+    return Card(
+        "card_45",
         "可憐",
         "かれん",
-        Janken.ROCK,
-        10,
+        Janken.SCISSORS,
+        11,
         Effect(EffectType.CHOOSE, "choose", None),
     )
-    other = Card("cx", "other", "おざー", Janken.ROCK, 9, None)
+
+
+def test_karen_choose_gain_points_increments_point_modifier():
+    karen = _karen()
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 11, None)
     state = GameState(
         player=PlayerState(hand=[karen]),
         npc=PlayerState(hand=[other]),
@@ -35,44 +43,72 @@ def test_karen_choose_activate_sets_must_reveal_on_opponent():
     state = resolve_round(state, karen, other)
     assert state.phase == Phase.INTERACTIVE_EFFECT
 
-    state = resume_round_effect(state, choice="activate")
+    state = resume_round_effect(state, choice="gain_points")
 
-    assert state.npc.must_reveal_played_card is False
-    assert state.npc.must_reveal_played_card_rounds == 2
+    assert state.player.point_modifier == 2
 
 
-def test_immune_blocks_karen_choose_reveal_effect_on_resume():
-    karen = Card(
-        "card_45",
-        "可憐",
-        "かれん",
+def test_karen_choose_return_and_flip_replaces_played_card_without_triggering_new_effect(
+    monkeypatch,
+):
+    karen = _karen()
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 11, None)
+    deck_card = Card(
+        "d1",
+        "山札",
+        "やまふだ",
         Janken.SCISSORS,
-        11,
-        Effect(EffectType.CHOOSE, "choose", None),
-    )
-    emily = Card(
-        "card_32",
-        "エミリー",
-        "えみりー",
-        Janken.SCISSORS,
-        13,
-        Effect(EffectType.IMMUNE, "immune", None),
+        20,
+        Effect(EffectType.BUFF, "+5", 5),
     )
     state = GameState(
-        player=PlayerState(hand=[karen]),
-        npc=PlayerState(hand=[emily]),
+        player=PlayerState(hand=[karen], deck=[deck_card]),
+        npc=PlayerState(hand=[other]),
     )
 
-    state = resolve_round(state, karen, emily)
+    state = resolve_round(state, karen, other)
     assert state.phase == Phase.INTERACTIVE_EFFECT
 
-    state = resume_round_effect(state, choice="activate")
+    monkeypatch.setattr(random, "shuffle", lambda _seq: None)
+    state = resume_round_effect(state, choice="return_and_flip")
 
-    assert state.npc.must_reveal_played_card_rounds == 0
-    assert any(
-        "可憐の効果: 相手は戦具効果を受けないため不発" in log
-        for log in state.battle_log
+    assert state.current_battle.player_card.id == deck_card.id
+    assert state.player.point_modifier == 0
+    assert [c.id for c in state.player.deck] == [karen.id]
+
+
+def test_karen_choose_return_and_flip_with_empty_deck_keeps_karen_on_field():
+    karen = _karen()
+    other = Card("cx", "other", "おざー", Janken.SCISSORS, 11, None)
+    state = GameState(
+        player=PlayerState(hand=[karen], deck=[]),
+        npc=PlayerState(hand=[other]),
     )
+
+    state = resolve_round(state, karen, other)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+
+    state = resume_round_effect(state, choice="return_and_flip")
+
+    assert state.current_battle.player_card.id == karen.id
+    assert state.player.deck == []
+    assert any("再び可憐がめくれた" in log for log in state.battle_log)
+
+
+def test_karen_choose_npc_side_uses_strategy_to_select_gain_points():
+    karen = _karen()
+    player_card = Card("cx", "other", "おざー", Janken.SCISSORS, 11, None)
+    state = GameState(
+        player=PlayerState(hand=[player_card]),
+        npc=PlayerState(hand=[karen]),
+    )
+
+    state = resolve_round(state, player_card, karen)
+    assert state.phase == Phase.INTERACTIVE_EFFECT
+
+    state = resolve_npc_pending_effects(state, FirstChoiceStrategy())
+
+    assert state.npc.point_modifier == 2
 
 
 def test_change_janken_arisa_rejudges_current_battle_mark():

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -431,24 +431,6 @@ def test_resolve_round_consumes_must_reveal_played_card_and_records_reveal(mock_
     assert next_state.revealed_this_round_side == Side.NPC
 
 
-def test_resolve_round_consumes_must_reveal_played_card_rounds(mock_cards):
-    p1, n1, p2, n2 = mock_cards
-    state = GameState(
-        player=PlayerState(hand=[p1, p2]),
-        npc=PlayerState(hand=[n1, n2], must_reveal_played_card_rounds=2),
-        phase=Phase.SELECT,
-    )
-
-    round_1 = resolve_round(state, p1, n1)
-    assert round_1.revealed_this_round == [n1]
-    assert round_1.npc.must_reveal_played_card_rounds == 1
-
-    round_2_start = proceed_to_next(round_1)
-    round_2 = resolve_round(round_2_start, p2, n2)
-    assert round_2.revealed_this_round == [n2]
-    assert round_2.npc.must_reveal_played_card_rounds == 0
-
-
 def test_proceed_to_next_resolves_remaining_forfeit_rounds(mock_cards):
     forfeited_1, npc_card, forfeited_2, forfeited_3 = mock_cards
     state = GameState(


### PR DESCRIPTION
## 概要

可憐 (card_45) の効果実装を `cards.jsonl` のカードテキストに一致させた。

これまで engine / UI / テスト すべてが「相手の出し札を2ラウンド公開強制」という古い仕様で動いており、現行カードテキストの「●自分のポイント+2 ●このカードを山札に戻して切り、山札の上から1枚をめくって場に出す(戦具効果は不発)」と完全に乖離していた (UI スクリーンショット参照)。

## 変更内容

- `_resume_choose` の `karen_choose` 分岐を `gain_points` / `return_and_flip` の二択に再実装 (`yuriko_choose` と同じ命名規約)
- `return_and_flip`: 場の可憐を山札に戻す → `random.shuffle` → 先頭1枚を場札に置き換え。新カードの戦具効果は effect_queue に積まないため発動しない (シャッフルで再び可憐がめくれた場合は「再び可憐がめくれた」とログ)
- NPC 戦略の `karen_choose` 分岐を `npc_strategy.choose_effect(["gain_points", "return_and_flip"], state)` に置き換え
- `app.py` の UI ラベルを新二択に更新
- 旧仕様専用の dead code を削除
  - `PlayerState.must_reveal_played_card_rounds: int`
  - `set_must_reveal_played_card_rounds()`
  - `apply_must_reveal_played_card` 内の `_rounds` 参照分岐
  - boolean 版 `must_reveal_played_card` は 紬 (card_51, `curse`) が利用中のため残置
- 旧仕様検証テストを削除し、新仕様向けテスト4件を追加 (gain_points 経路 / return_and_flip 経路 / 山札空時のフォールバック / NPC 経路)

## 注意事項

- `return_and_flip` 後の場札差し替えで janken の再判定は個別ハンドラでは行わない。これは既存の swap (真) / tutor_play (麗花) と同じ規約 (タイ解決機構の責務)
- UI 側はラベル文言の差し替えのみのため目視確認のみ実施 (ロジック変更なし)

## テスト

```bash
.venv/bin/python -m pytest      # 165 passed
ruff format                      # 47 files left unchanged
ruff check --fix --extend-select I  # All checks passed
```
